### PR TITLE
fix: Add uv cache dir to ReadWritePaths to prevent crash loop

### DIFF
--- a/deploy/biomapper2-api.service
+++ b/deploy/biomapper2-api.service
@@ -29,7 +29,7 @@ NoNewPrivileges=true
 PrivateTmp=true
 ProtectSystem=strict
 ProtectHome=read-only
-ReadWritePaths=/home/ubuntu/biomapper2/results /home/ubuntu/biomapper2/cache
+ReadWritePaths=/home/ubuntu/biomapper2/results /home/ubuntu/biomapper2/cache /home/ubuntu/.cache/uv /tmp
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
uv requires a writable cache directory (~/.cache/uv by default). Under ProtectHome=read-only, this path is read-only, causing "Read-only file system (os error 30)" errors on service restart.

Adding ~/.cache/uv and /tmp to ReadWritePaths resolves the crash loop while retaining ProtectHome and other hardening directives.

Root cause timeline:
- Feb 17: Service file added with ProtectHome=read-only (worked fine)
- Apr 13: Last successful deploy (run #24367903266) — service restarted with the then-current uv version, no issues
- Apr 15 21:16 UTC: uv updated to 0.11.7 on disk (unknown trigger — no shell history, cron, or journal entry explains it), but biomapper2 was never restarted so the running process kept using the old binary
- Apr 23 19:26 UTC: PR #65 merge triggered deploy, first restart since Apr 13 — new uv 0.11.7 loaded from disk, attempted write to ~/.cache/uv/.tmp*, hit read-only mount from ProtectHome, crash loop (220+ restarts, run #24854523364)

The service ran continuously from Apr 13–23 (PIDs 338062/338063), masking the incompatibility between the uv upgrade and the existing ProtectHome=read-only setting.