### PR TITLE
feat: HGNC human-preference re-ranking for gene/protein resolution

### DIFF
--- a/src/biomapper2/api/models/requests.py
+++ b/src/biomapper2/api/models/requests.py
@@ -24,6 +24,18 @@ class MappingOptions(BaseModel):
         default=None,
         description="Allowed vocabulary name(s) to map to (e.g., 'refmet', 'chebi')",
     )
+    prefer_human: bool = Field(
+        default=True,
+        description=(
+            "For gene/protein entities, prefer the human (HGNC-bearing) candidate that matches the "
+            "queried symbol over a wrong-species ortholog. Default True. Set False to restore legacy "
+            "top-scored selection. No effect on metabolites or other non-gene/protein categories."
+        ),
+    )
+
+    # Ignore unknown fields so a newer client sending extra options to an older server does not 422.
+    # (Pydantic v2 already defaults to ignore; set explicitly as documentation of the contract.)
+    model_config = {"extra": "ignore"}
 
 
 class EntityMappingRequest(BaseModel):

--- a/src/biomapper2/api/routes/mapping.py
+++ b/src/biomapper2/api/routes/mapping.py
@@ -96,6 +96,7 @@ async def map_entity(
             array_delimiters=body.options.array_delimiters,
             annotation_mode=body.options.annotation_mode,
             annotators=body.options.annotators,
+            prefer_human=body.options.prefer_human,
         )
 
         result = extract_mapping_result(mapped_item, body.name)
@@ -163,6 +164,7 @@ async def map_batch(
                 array_delimiters=entity_req.options.array_delimiters,
                 annotation_mode=entity_req.options.annotation_mode,
                 annotators=entity_req.options.annotators,
+                prefer_human=entity_req.options.prefer_human,
             )
 
             result = extract_mapping_result(mapped_item, entity_req.name)
@@ -205,6 +207,7 @@ async def map_dataset(
     annotation_mode: str = "missing",
     annotators: str | None = None,  # Comma-separated
     vocab: str | None = None,
+    prefer_human: bool = True,
     _api_key: str = Depends(validate_api_key),
 ) -> DatasetMappingResponse:
     """
@@ -251,6 +254,7 @@ async def map_dataset(
             vocab=vocab,
             annotation_mode=annotation_mode,  # type: ignore
             annotators=annotator_list,
+            prefer_human=prefer_human,
         )
 
     except Exception as e:
@@ -279,6 +283,7 @@ async def map_dataset_stream(
     annotation_mode: str = "missing",
     annotators: str | None = None,
     vocab: str | None = None,
+    prefer_human: bool = True,
     _api_key: str = Depends(validate_api_key),
 ) -> StreamingResponse:
     """
@@ -324,6 +329,7 @@ async def map_dataset_stream(
                     vocab=vocab,
                     annotation_mode=annotation_mode,  # type: ignore
                     annotators=annotator_list,
+                    prefer_human=prefer_human,
                 )
 
                 result = {

--- a/src/biomapper2/config.py
+++ b/src/biomapper2/config.py
@@ -43,3 +43,12 @@ def get_kestrel_api_key() -> str:
 KESTREL_BATCHING_ENABLED = True  # Set to False to disable batching (for performance testing)
 KESTREL_BATCH_SIZE_SEARCH = 1000  # For text-search, vector-search, hybrid-search
 KESTREL_BATCH_SIZE_CANONICALIZE = 2000  # For canonicalize endpoint
+
+# Human-preference re-ranking for gene/protein resolution (see docs/plans HGNC plan).
+# When prefer_human is active, hybrid-search retrieves this many candidates (instead of 1) so the
+# human node — which often ranks below the wrong-species ortholog — is actually returned. Live spike
+# (2026-06-15) found recoverable human nodes at rank ~#4; 20 gives ample margin.
+HYBRID_SEARCH_LIMIT = 20
+# Human-only CURIE prefixes. HGNC assigns IDs only to human genes, so its presence in a hybrid-search
+# row's `prefixes` marks the human node. Any prefix added here must itself be human-exclusive.
+HUMAN_MARKER_PREFIXES = {"HGNC"}

--- a/src/biomapper2/core/annotation_engine.py
+++ b/src/biomapper2/core/annotation_engine.py
@@ -44,6 +44,7 @@ class AnnotationEngine:
         prefixes: list[str],
         mode: AnnotationMode = "missing",
         annotators: list[str] | None = None,
+        prefer_human: bool = True,
     ) -> pd.DataFrame | pd.Series:
         """
         Annotate entity with additional vocab IDs, obtained using various internal or external methods.
@@ -59,6 +60,9 @@ class AnnotationEngine:
                 - 'missing': Only annotate entities without provided_ids (default)
                 - 'none': Skip annotation entirely (returns empty)
             annotators: Optional list of annotators to use (by slug). If None, annotators are selected automatically.
+            prefer_human: When True, prefer the human (HGNC-bearing) candidate for gene/protein
+                categories. This engine gates applicability by category (see below) and passes the
+                resolved, effective flag to the annotators.
 
         Returns:
             AssignedIDsDict (in a named Series) for single entity, and in a single-column
@@ -68,7 +72,14 @@ class AnnotationEngine:
         if mode not in valid_modes:
             raise ValueError(f"Invalid mode '{mode}'. Must be one of: {valid_modes}")
 
-        logging.info(f"Beginning annotation step.. (mode={mode}, annotators={annotators})")
+        # Human-preference applies only to gene/protein categories (and their Biolink descendants).
+        # Resolve the effective flag here so annotators receive an already-gated boolean.
+        effective_prefer_human = prefer_human and self._is_human_applicable_category(category)
+
+        logging.info(
+            f"Beginning annotation step.. (mode={mode}, annotators={annotators}, "
+            f"prefer_human={prefer_human}, effective_prefer_human={effective_prefer_human})"
+        )
 
         # Skip annotation if user requested it
         if mode == "none":
@@ -99,16 +110,37 @@ class AnnotationEngine:
 
             if isinstance(item, pd.DataFrame):
                 return self._annotate_dataframe(
-                    item, name_field, provided_id_fields, mode, category, prefixes, annotators_to_use
+                    item,
+                    name_field,
+                    provided_id_fields,
+                    mode,
+                    category,
+                    prefixes,
+                    annotators_to_use,
+                    effective_prefer_human,
                 )
             else:
                 return self._annotate_single(
-                    item, name_field, provided_id_fields, mode, category, prefixes, annotators_to_use
+                    item,
+                    name_field,
+                    provided_id_fields,
+                    mode,
+                    category,
+                    prefixes,
+                    annotators_to_use,
+                    effective_prefer_human,
                 )
         else:
             return self._get_empty_assigned_ids(item)
 
     # ------------------------------------- Helper methods --------------------------------------- #
+
+    def _is_human_applicable_category(self, category: str) -> bool:
+        """True if the category is a gene/protein (or Biolink descendant), where human-preference applies."""
+        gene_protein = self.biolink_client.get_descendants("biolink:Gene") | self.biolink_client.get_descendants(
+            "biolink:Protein"
+        )
+        return category in gene_protein
 
     def _select_annotators(self, category: str) -> list[str]:
         """Select appropriate annotators based on entity type (returns their slugs)."""
@@ -134,6 +166,7 @@ class AnnotationEngine:
         category: str,
         prefixes: list[str],
         annotators: list,
+        prefer_human: bool = True,
     ) -> pd.DataFrame:
         """Annotate an entire DataFrame. Returns a single-column DataFrame containing AssignedIDsDicts."""
         if mode == "missing":
@@ -157,7 +190,9 @@ class AnnotationEngine:
 
             for annotator in annotators:
                 prepared_df = annotator.prepare(items_to_annotate, provided_id_fields)
-                annotations_col = annotator.get_annotations_bulk(prepared_df, name_field, category, prefixes)
+                annotations_col = annotator.get_annotations_bulk(
+                    prepared_df, name_field, category, prefixes, prefer_human=prefer_human
+                )
                 annotated_rows = pd.Series(
                     [self._merge_nested_dicts(d1, d2) for d1, d2 in zip(annotated_rows, annotations_col)],
                     index=annotated_rows.index,
@@ -177,6 +212,7 @@ class AnnotationEngine:
         category: str,
         prefixes: list[str],
         annotators: list,
+        prefer_human: bool = True,
     ) -> pd.Series:
         """Annotate a single entity. Returns named series containing AssignedIDsDict."""
         # If user requested it, skip entities that have any provided IDs
@@ -190,7 +226,9 @@ class AnnotationEngine:
         assigned_ids = dict()  # All annotations will be merged into this
         for annotator in annotators:
             prepared_entity = annotator.prepare(item, provided_id_fields)
-            entity_annotations = annotator.get_annotations(prepared_entity, name_field, category, prefixes)
+            entity_annotations = annotator.get_annotations(
+                prepared_entity, name_field, category, prefixes, prefer_human=prefer_human
+            )
             assigned_ids: AssignedIDsDict = self._merge_nested_dicts(assigned_ids, entity_annotations)
 
         return pd.Series({"assigned_ids": assigned_ids})  # Named Series

--- a/src/biomapper2/core/annotation_engine.py
+++ b/src/biomapper2/core/annotation_engine.py
@@ -6,6 +6,7 @@ Queries external APIs or uses other creative approaches to retrieve additional i
 
 import logging
 from copy import deepcopy
+from functools import cached_property
 from typing import Any
 
 import pandas as pd
@@ -135,12 +136,21 @@ class AnnotationEngine:
 
     # ------------------------------------- Helper methods --------------------------------------- #
 
-    def _is_human_applicable_category(self, category: str) -> bool:
-        """True if the category is a gene/protein (or Biolink descendant), where human-preference applies."""
-        gene_protein = self.biolink_client.get_descendants("biolink:Gene") | self.biolink_client.get_descendants(
+    @cached_property
+    def _human_applicable_categories(self) -> set[str]:
+        """Gene/Protein and their Biolink descendants — categories where human-preference applies.
+
+        Cached per instance: the Biolink hierarchy is static at runtime, so this avoids recomputing the
+        descendant union on every annotate() call (which happens once per entity on the single/stream paths).
+        Lazy (computed on first use) so constructing the engine doesn't force the lookup eagerly.
+        """
+        return self.biolink_client.get_descendants("biolink:Gene") | self.biolink_client.get_descendants(
             "biolink:Protein"
         )
-        return category in gene_protein
+
+    def _is_human_applicable_category(self, category: str) -> bool:
+        """True if the category is a gene/protein (or Biolink descendant), where human-preference applies."""
+        return category in self._human_applicable_categories
 
     def _select_annotators(self, category: str) -> list[str]:
         """Select appropriate annotators based on entity type (returns their slugs)."""

--- a/src/biomapper2/core/annotators/base.py
+++ b/src/biomapper2/core/annotators/base.py
@@ -35,6 +35,7 @@ class BaseAnnotator(ABC):  # Inherit from ABC
         name_field: str,
         category: str,
         prefixes: list[str] | None = None,
+        prefer_human: bool = True,
         cache: dict | None = None,
     ) -> AssignedIDsDict:
         """
@@ -45,6 +46,9 @@ class BaseAnnotator(ABC):  # Inherit from ABC
             name_field: Name of the field containing the entity name
             category: Biolink category (standardized entity type)
             prefixes: Allowed (standardized) curie prefixes to map to (e.g., 'CHEBI', 'MONDO')
+            prefer_human: When True (and the category is gene/protein-applicable, as gated by the
+                engine), prefer the human (HGNC-bearing) candidate. Honored only by annotators where
+                a human marker applies; others accept and ignore it.
             cache: Optional pre-fetched results from bulk API call
 
         Returns:
@@ -54,7 +58,12 @@ class BaseAnnotator(ABC):  # Inherit from ABC
 
     @abstractmethod
     def get_annotations_bulk(
-        self, entities: pd.DataFrame, name_field: str, category: str, prefixes: list[str] | None = None
+        self,
+        entities: pd.DataFrame,
+        name_field: str,
+        category: str,
+        prefixes: list[str] | None = None,
+        prefer_human: bool = True,
     ) -> pd.Series:  # Series of AssignedIdsDicts
         """
         Get annotations for multiple entities with bulk API call.
@@ -64,6 +73,7 @@ class BaseAnnotator(ABC):  # Inherit from ABC
             name_field: Name of the column containing entity names
             category: Biolink category (standardized entity type)
             prefixes: Allowed (standardized) curie prefixes to map to (e.g., 'CHEBI', 'MONDO')
+            prefer_human: See get_annotations. Accepted by all annotators; honored where applicable.
 
         Returns:
             Column (Series) of annotation results (same index as input)

--- a/src/biomapper2/core/annotators/kestrel_hybrid.py
+++ b/src/biomapper2/core/annotators/kestrel_hybrid.py
@@ -107,7 +107,7 @@ class KestrelHybridSearchAnnotator(BaseAnnotator):
         if not prefer_human:
             return term_results[0]
 
-        human = [r for r in term_results if HUMAN_MARKER_PREFIXES & set(r.get("prefixes", []))]
+        human = [r for r in term_results if HUMAN_MARKER_PREFIXES & set(r.get("prefixes") or [])]
         if not human:
             return term_results[0]
 

--- a/src/biomapper2/core/annotators/kestrel_hybrid.py
+++ b/src/biomapper2/core/annotators/kestrel_hybrid.py
@@ -1,9 +1,9 @@
 import logging
-from typing import Any
+from typing import Any, cast
 
 import pandas as pd
 
-from ...config import KESTREL_BATCH_SIZE_SEARCH
+from ...config import HUMAN_MARKER_PREFIXES, HYBRID_SEARCH_LIMIT, KESTREL_BATCH_SIZE_SEARCH
 from ...utils import AssignedIDsDict, kestrel_request, text_is_not_empty
 from .base import BaseAnnotator
 
@@ -18,9 +18,16 @@ class KestrelHybridSearchAnnotator(BaseAnnotator):
         name_field: str,
         category: str,
         prefixes: list[str] | None = None,
+        prefer_human: bool = True,
         cache: dict | None = None,
     ) -> AssignedIDsDict:
-        """Implements BaseAnnotator.get_annotations"""
+        """Implements BaseAnnotator.get_annotations.
+
+        When ``prefer_human`` is True the annotator retrieves multiple candidates and selects the
+        human (HGNC-bearing) one that matches the queried symbol, falling back to the top-scored
+        candidate on a miss (see ``_select_result``). When False it keeps the legacy top-1 behavior.
+        The engine passes the *applicability-gated* value (True only for gene/protein categories).
+        """
 
         # Extract the value to search
         search_term = entity.get(name_field)
@@ -29,14 +36,15 @@ class KestrelHybridSearchAnnotator(BaseAnnotator):
             if cache:
                 term_results = cache.get(search_term)
             else:
-                results = self._kestrel_hybrid_search(search_term, category, prefixes, limit=1)
+                limit = HYBRID_SEARCH_LIMIT if prefer_human else 1
+                results = self._kestrel_hybrid_search(search_term, category, prefixes, limit=limit)
                 term_results = results[search_term]
 
             annotations: dict[str, dict[str, dict[str, Any]]] = {}
-            if term_results:
-                first_result = term_results[0]
-                node_id = first_result["id"]
-                score = first_result["score"]
+            chosen = self._select_result(term_results, search_term, prefer_human)
+            if chosen is not None:
+                node_id = chosen["id"]
+                score = chosen["score"]
                 vocab, local_id = node_id.split(":", 1)
                 annotations.setdefault(vocab, {})[local_id] = {"score": score}
 
@@ -51,6 +59,7 @@ class KestrelHybridSearchAnnotator(BaseAnnotator):
         name_field: str,
         category: str,
         prefixes: list[str] | None = None,
+        prefer_human: bool = True,
     ) -> pd.Series:  # Series of AssignedIDsDicts
         """Implements BaseAnnotator.get_annotations_bulk"""
 
@@ -58,16 +67,61 @@ class KestrelHybridSearchAnnotator(BaseAnnotator):
         search_terms = [t for t in entities[name_field].tolist() if text_is_not_empty(t)]
 
         logging.info(f"Getting hybrid search results from Kestrel API for {len(entities)} entities")
-        results = self._kestrel_hybrid_search(search_terms, category, prefixes, limit=1)
+        # Only enlarge the candidate window when human-preference is active (keeps payloads small for
+        # metabolite/other bulk jobs where the re-ranking does not apply).
+        limit = HYBRID_SEARCH_LIMIT if prefer_human else 1
+        results = self._kestrel_hybrid_search(search_terms, category, prefixes, limit=limit)
 
-        # Annotate each entity using the results from the bulk request
+        # Annotate each entity using the results from the bulk request. The internal re-dispatch MUST
+        # forward prefer_human, otherwise the bulk path would silently use the get_annotations default.
         assigned_ids_col = entities.apply(
-            self.get_annotations, axis=1, cache=results, name_field=name_field, category=category, prefixes=prefixes
+            self.get_annotations,
+            axis=1,
+            cache=results,
+            name_field=name_field,
+            category=category,
+            prefixes=prefixes,
+            prefer_human=prefer_human,
         )
 
-        return assigned_ids_col
+        return cast(pd.Series, assigned_ids_col)
 
     # ----------------------------------------- Helper methods ----------------------------------------------- #
+
+    @staticmethod
+    def _select_result(term_results: list[dict] | None, search_term: str, prefer_human: bool) -> dict | None:
+        """Select one candidate row from a hybrid-search result list.
+
+        Two-tier human preference (finalized from the 2026-06-15 live spike):
+        1. Filter to human (HGNC-bearing) rows; if none, fall back to the top-scored candidate.
+        2. Among human rows, prefer those whose symbol matches the query (``name`` or a synonym);
+           if none match, keep all human rows (avoids over-rejecting alias queries to an ortholog).
+        3. Return the highest-scoring row of that pool.
+
+        The HGNC filter must precede the symbol match because orthologs share the human row's ``name``
+        (same symbol, different species) — HGNC separates species, the symbol match picks the right gene.
+        Returns None for an empty/None result list.
+        """
+        if not term_results:
+            return None
+        if not prefer_human:
+            return term_results[0]
+
+        human = [r for r in term_results if HUMAN_MARKER_PREFIXES & set(r.get("prefixes", []))]
+        if not human:
+            return term_results[0]
+
+        exact = [r for r in human if KestrelHybridSearchAnnotator._symbol_matches(r, search_term)]
+        pool = exact if exact else human
+        return max(pool, key=lambda r: r.get("score", 0))
+
+    @staticmethod
+    def _symbol_matches(row: dict, search_term: str) -> bool:
+        """True if the row's ``name`` equals the query (case-insensitive) or the query is a synonym."""
+        term = str(search_term).strip().lower()
+        if str(row.get("name", "")).strip().lower() == term:
+            return True
+        return any(str(s).strip().lower() == term for s in row.get("synonyms", []) or [])
 
     @staticmethod
     def _kestrel_hybrid_search(

--- a/src/biomapper2/core/annotators/kestrel_text.py
+++ b/src/biomapper2/core/annotators/kestrel_text.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any
+from typing import Any, cast
 
 import pandas as pd
 
@@ -18,6 +18,7 @@ class KestrelTextSearchAnnotator(BaseAnnotator):
         name_field: str,
         category: str,
         prefixes: list[str] | None = None,
+        prefer_human: bool = True,  # accepted for interface parity; not applicable to text search
         cache: dict | None = None,
     ) -> AssignedIDsDict:
         """Implements BaseAnnotator.get_annotations"""
@@ -51,6 +52,7 @@ class KestrelTextSearchAnnotator(BaseAnnotator):
         name_field: str,
         category: str,
         prefixes: list[str] | None = None,
+        prefer_human: bool = True,  # accepted for interface parity; not applicable to text search
     ) -> pd.Series:  # Series of AssignedIDsDicts
         """Implements BaseAnnotator.get_annotations_bulk"""
 
@@ -65,7 +67,7 @@ class KestrelTextSearchAnnotator(BaseAnnotator):
             self.get_annotations, axis=1, cache=results, name_field=name_field, category=category, prefixes=prefixes
         )
 
-        return assigned_ids_col
+        return cast(pd.Series, assigned_ids_col)
 
     # ----------------------------------------- Helper methods ----------------------------------------------- #
 

--- a/src/biomapper2/core/annotators/kestrel_text.py
+++ b/src/biomapper2/core/annotators/kestrel_text.py
@@ -64,7 +64,13 @@ class KestrelTextSearchAnnotator(BaseAnnotator):
 
         # Annotate each entity using the results from the bulk request
         assigned_ids_col = entities.apply(
-            self.get_annotations, axis=1, cache=results, name_field=name_field, category=category, prefixes=prefixes
+            self.get_annotations,
+            axis=1,
+            cache=results,
+            name_field=name_field,
+            category=category,
+            prefixes=prefixes,
+            prefer_human=prefer_human,
         )
 
         return cast(pd.Series, assigned_ids_col)

--- a/src/biomapper2/core/annotators/kestrel_vector.py
+++ b/src/biomapper2/core/annotators/kestrel_vector.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any
+from typing import Any, cast
 
 import pandas as pd
 
@@ -18,6 +18,7 @@ class KestrelVectorSearchAnnotator(BaseAnnotator):
         name_field: str,
         category: str,
         prefixes: list[str] | None = None,
+        prefer_human: bool = True,  # accepted for interface parity; not applicable to vector search
         cache: dict | None = None,
     ) -> AssignedIDsDict:
         """Implements BaseAnnotator.get_annotations"""
@@ -51,6 +52,7 @@ class KestrelVectorSearchAnnotator(BaseAnnotator):
         name_field: str,
         category: str,
         prefixes: list[str] | None = None,
+        prefer_human: bool = True,  # accepted for interface parity; not applicable to vector search
     ) -> pd.Series:  # Series of AssignedIDsDicts
         """Implements BaseAnnotator.get_annotations_bulk"""
 
@@ -65,7 +67,7 @@ class KestrelVectorSearchAnnotator(BaseAnnotator):
             self.get_annotations, axis=1, cache=results, name_field=name_field, category=category, prefixes=prefixes
         )
 
-        return assigned_ids_col
+        return cast(pd.Series, assigned_ids_col)
 
     # ----------------------------------------- Helper methods ----------------------------------------------- #
 

--- a/src/biomapper2/core/annotators/kestrel_vector.py
+++ b/src/biomapper2/core/annotators/kestrel_vector.py
@@ -64,7 +64,13 @@ class KestrelVectorSearchAnnotator(BaseAnnotator):
 
         # Annotate each entity using the results from the bulk request
         assigned_ids_col = entities.apply(
-            self.get_annotations, axis=1, cache=results, name_field=name_field, category=category, prefixes=prefixes
+            self.get_annotations,
+            axis=1,
+            cache=results,
+            name_field=name_field,
+            category=category,
+            prefixes=prefixes,
+            prefer_human=prefer_human,
         )
 
         return cast(pd.Series, assigned_ids_col)

--- a/src/biomapper2/core/annotators/metabolomics_workbench.py
+++ b/src/biomapper2/core/annotators/metabolomics_workbench.py
@@ -2,7 +2,7 @@
 
 import logging
 from datetime import timedelta
-from typing import Any
+from typing import Any, cast
 from urllib.parse import quote
 
 import pandas as pd
@@ -45,6 +45,7 @@ class MetabolomicsWorkbenchAnnotator(BaseAnnotator):
         name_field: str,
         category: str,
         prefixes: list[str] | None = None,
+        prefer_human: bool = True,  # accepted for interface parity; metabolites have no HGNC analogue
         cache: dict | None = None,
     ) -> AssignedIDsDict:
         """Implements BaseAnnotator.get_annotations"""
@@ -83,6 +84,7 @@ class MetabolomicsWorkbenchAnnotator(BaseAnnotator):
         name_field: str,
         category: str,
         prefixes: list[str] | None = None,
+        prefer_human: bool = True,  # accepted for interface parity; metabolites have no HGNC analogue
     ) -> pd.Series:
         """Implements BaseAnnotator.get_annotations_bulk"""
 
@@ -98,7 +100,7 @@ class MetabolomicsWorkbenchAnnotator(BaseAnnotator):
             self.get_annotations, axis=1, cache=cache, name_field=name_field, category=category, prefixes=prefixes
         )
 
-        return assigned_ids_col
+        return cast(pd.Series, assigned_ids_col)
 
     def _fetch_refmet_data(self, metabolite_name: str) -> dict[str, Any] | None:
         """Fetch RefMet data from the Metabolomics Workbench match API.

--- a/src/biomapper2/core/annotators/metabolomics_workbench.py
+++ b/src/biomapper2/core/annotators/metabolomics_workbench.py
@@ -97,7 +97,13 @@ class MetabolomicsWorkbenchAnnotator(BaseAnnotator):
 
         # Apply get_annotations to each row using the cache
         assigned_ids_col = entities.apply(
-            self.get_annotations, axis=1, cache=cache, name_field=name_field, category=category, prefixes=prefixes
+            self.get_annotations,
+            axis=1,
+            cache=cache,
+            name_field=name_field,
+            category=category,
+            prefixes=prefixes,
+            prefer_human=prefer_human,
         )
 
         return cast(pd.Series, assigned_ids_col)

--- a/src/biomapper2/mapper.py
+++ b/src/biomapper2/mapper.py
@@ -55,6 +55,7 @@ class Mapper:
         stop_on_invalid_id: bool = False,
         annotation_mode: AnnotationMode = "missing",
         annotators: list[str] | None = None,
+        prefer_human: bool = True,
     ) -> pd.Series | dict[str, Any]:
         """
         Map a single entity to knowledge graph nodes.
@@ -94,6 +95,7 @@ class Mapper:
             prefixes=prefixes,
             mode=annotation_mode,
             annotators=annotators,
+            prefer_human=prefer_human,
         )
         assert isinstance(annotation_result, pd.Series)
         entity = entity.update_from(annotation_result)
@@ -139,6 +141,7 @@ class Mapper:
         output_dir: str | Path = PROJECT_ROOT / "results",
         annotation_mode: AnnotationMode = "missing",
         annotators: list[str] | None = None,
+        prefer_human: bool = True,
     ) -> tuple[str, dict[str, Any]]:
         """
         Map all entities in a dataset to knowledge graph nodes.
@@ -218,6 +221,7 @@ class Mapper:
             prefixes=prefixes,
             mode=annotation_mode,
             annotators=annotators,
+            prefer_human=prefer_human,
         )
         df = df.join(annotation_df)
         logging.info(f"After step 1 (annotation), df is: \n{df}")

--- a/tests/test_human_gene_gold_set.py
+++ b/tests/test_human_gene_gold_set.py
@@ -1,0 +1,101 @@
+"""Live merge-gate validation: human genes/proteins must resolve to the human node, not an ortholog.
+
+Marked `integration` (hits the live Kestrel API). Runs the full pipeline via Mapper.map_entity_to_kg
+with the default-on prefer_human behavior, asserts each positive gold entity resolves to the expected
+human NCBIGene carrying an HGNC marker, and persists a timestamped report (per the experiment-artifact
+SOP). GH1 is a negative control: its human node is absent from Kestrel hybrid-search even at limit=50
+(verified 2026-06-15), so it is expected to fall back gracefully and is counted in the fallback fraction.
+"""
+
+import json
+from datetime import datetime, timezone
+
+import pytest
+
+from biomapper2.config import PROJECT_ROOT
+
+# Positive cases: must resolve to the expected human NCBIGene (verified at rank ~#4 in the Unit 1 spike).
+# Includes a paralog pair (TNFRSF1A/TNFRSF1B) to exercise the R7 wrong-paralog guard against live data.
+POSITIVE_GOLD = {
+    "TNFRSF1A": "NCBIGene:7132",
+    "TNFRSF1B": "NCBIGene:7133",
+    "LDLR": "NCBIGene:3949",
+}
+# Negative control: human node absent from Kestrel candidates -> expected to fall back (Kestrel recall gap).
+NEGATIVE_CONTROL = {"GH1": "NCBIGene:2688"}
+
+
+def _has_hgnc(result: dict) -> bool:
+    """True if the resolved node carries an HGNC marker in its equivalent ids."""
+    return "HGNC" in json.dumps(result.get("kg_equivalent_ids", {}))
+
+
+def _map_gene(shared_mapper, name: str) -> dict:
+    return shared_mapper.map_entity_to_kg(
+        item={"name": name},
+        name_field="name",
+        provided_id_fields=[],
+        entity_type="gene",
+    )
+
+
+@pytest.fixture(scope="module")
+def gold_set_run(shared_mapper):
+    """Run the full gold set live once, persist a timestamped report, and return the per-entity results."""
+    rows = []
+    for name, expected in {**POSITIVE_GOLD, **NEGATIVE_CONTROL}.items():
+        result = _map_gene(shared_mapper, name)
+        chosen = result.get("chosen_kg_id")
+        rows.append(
+            {
+                "name": name,
+                "expected_human": expected,
+                "chosen_kg_id": chosen,
+                "is_expected_human": chosen == expected,
+                "has_hgnc": _has_hgnc(result),
+                "is_positive": name in POSITIVE_GOLD,
+            }
+        )
+
+    positives = [r for r in rows if r["is_positive"]]
+    fell_back = [r for r in rows if not r["is_expected_human"]]
+    report = {
+        "generated_utc": datetime.now(timezone.utc).isoformat(),
+        "prefer_human": True,
+        "n_total": len(rows),
+        "n_positive": len(positives),
+        "n_positive_resolved": sum(r["is_expected_human"] for r in positives),
+        "fallback_fraction": round(len(fell_back) / len(rows), 3),
+        "rows": rows,
+    }
+
+    out_dir = PROJECT_ROOT / "results"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    out_path = out_dir / f"hgnc_gold_set_{stamp}.json"
+    out_path.write_text(json.dumps(report, indent=2))
+    print(f"\n[gold-set] report saved to {out_path} (fallback_fraction={report['fallback_fraction']})")
+
+    return report
+
+
+@pytest.mark.integration
+class TestHumanGeneGoldSet:
+    @pytest.mark.parametrize("name", sorted(POSITIVE_GOLD))
+    def test_positive_resolves_to_human_node(self, gold_set_run, name):
+        """Each positive gold entity resolves to the expected human NCBIGene AND carries an HGNC marker."""
+        row = next(r for r in gold_set_run["rows"] if r["name"] == name)
+        assert row["chosen_kg_id"] == POSITIVE_GOLD[name], f"{name} -> {row['chosen_kg_id']} (expected human)"
+        assert row["has_hgnc"], f"{name} resolved node lacks an HGNC marker"
+
+    def test_gh1_negative_control_falls_back_gracefully(self, gold_set_run):
+        """GH1's human node is unreachable in Kestrel -> pipeline must return a node, not crash."""
+        row = next(r for r in gold_set_run["rows"] if r["name"] == "GH1")
+        assert row["chosen_kg_id"] is not None  # graceful fallback (honest miss), no exception
+        assert not row["is_expected_human"]  # documents the known Kestrel-recall residual
+
+    def test_fallback_fraction_reported(self, gold_set_run):
+        """The run quantifies and persists the fallback fraction (R8 observability)."""
+        assert 0.0 <= gold_set_run["fallback_fraction"] <= 1.0
+        # All positives should resolve; only the negative control is expected to fall back.
+        assert gold_set_run["n_positive_resolved"] == gold_set_run["n_positive"]

--- a/tests/test_human_gene_gold_set.py
+++ b/tests/test_human_gene_gold_set.py
@@ -89,10 +89,27 @@ class TestHumanGeneGoldSet:
         assert row["has_hgnc"], f"{name} resolved node lacks an HGNC marker"
 
     def test_gh1_negative_control_falls_back_gracefully(self, gold_set_run):
-        """GH1's human node is unreachable in Kestrel -> pipeline must return a node, not crash."""
+        """GH1's human node is unreachable in Kestrel -> pipeline must return a node, not crash.
+
+        This asserts only graceful behavior (a node is chosen), which holds whether or not the Kestrel
+        recall gap is ever fixed -- so it is NOT brittle.
+        """
         row = next(r for r in gold_set_run["rows"] if r["name"] == "GH1")
         assert row["chosen_kg_id"] is not None  # graceful fallback (honest miss), no exception
-        assert not row["is_expected_human"]  # documents the known Kestrel-recall residual
+
+    @pytest.mark.xfail(
+        reason=(
+            "Known Kestrel recall gap: the human GH1 node (NCBIGene:2688) is absent from hybrid-search "
+            "even at limit=50 (verified 2026-06-15). xfail (strict=False) documents the gap without "
+            "blocking CI; it auto-passes (xpass) once Kestrel indexes the human GH1 node -- at which "
+            "point remove this marker."
+        ),
+        strict=False,
+    )
+    def test_gh1_should_resolve_to_human_when_kestrel_gap_closes(self, gold_set_run):
+        """Records the desired GH1 outcome; xfails today, xpasses when the recall gap is fixed."""
+        row = next(r for r in gold_set_run["rows"] if r["name"] == "GH1")
+        assert row["chosen_kg_id"] == NEGATIVE_CONTROL["GH1"]
 
     def test_fallback_fraction_reported(self, gold_set_run):
         """The run quantifies and persists the fallback fraction (R8 observability)."""

--- a/tests/test_kestrel_hybrid_selection.py
+++ b/tests/test_kestrel_hybrid_selection.py
@@ -1,0 +1,89 @@
+"""Unit tests for HGNC human-preference candidate selection in the hybrid-search annotator.
+
+Mirrors the live Kestrel hybrid-search row shape verified 2026-06-15 (Unit 1 spike):
+each row carries id/score/name/prefixes (plus equivalent_ids/neighbors_count, unused here).
+Human gene rows carry "HGNC" in `prefixes`; orthologs and ENSEMBL transcripts never do.
+Orthologs can share the same `name` as the human row, so the HGNC filter must come first.
+"""
+
+from biomapper2.core.annotators.kestrel_hybrid import KestrelHybridSearchAnnotator
+
+select = KestrelHybridSearchAnnotator._select_result
+
+
+def _row(node_id: str, score: float, name: str, prefixes: list[str], **extra):
+    return {"id": node_id, "score": score, "name": name, "prefixes": prefixes, **extra}
+
+
+# Realistic TNFRSF1A candidate set (abridged from the live spike): ortholog #1, human at #4.
+TNFRSF1A_ROWS = [
+    _row("NCBIGene:397020", 4.876, "TNFRSF1A", ["NCBIGene", "RGD", "UniProtKB", "ENSEMBL"]),
+    _row("NCBIGene:406471", 3.333, "tnfrsf1a", ["NCBIGene", "UniProtKB", "ZFIN", "ENSEMBL"]),
+    _row("NCBIGene:7132", 2.406, "TNFRSF1A", ["UMLS", "OMIM", "NCBIGene", "HGNC", "NCIT", "ENSEMBL"]),
+    _row("ENSEMBL:ENST00000162749", 1.491, "TNFRSF1A-201", ["ENSEMBL"]),
+]
+
+
+class TestSelectResult:
+    def test_human_below_top_is_selected(self):
+        """Happy path: HGNC-bearing human row (#4, lower score) chosen over top-scored ortholog."""
+        chosen = select(TNFRSF1A_ROWS, "TNFRSF1A", prefer_human=True)
+        assert chosen is not None
+        assert chosen["id"] == "NCBIGene:7132"
+
+    def test_human_at_top_is_selected(self):
+        """Happy path: top-scored row already carries HGNC and matches the symbol -> chosen."""
+        rows = [
+            _row("NCBIGene:7132", 4.9, "TNFRSF1A", ["NCBIGene", "HGNC", "ENSEMBL"]),
+            _row("NCBIGene:397020", 4.8, "TNFRSF1A", ["NCBIGene", "RGD"]),
+        ]
+        chosen = select(rows, "TNFRSF1A", prefer_human=True)
+        assert chosen is not None
+        assert chosen["id"] == "NCBIGene:7132"
+
+    def test_higher_scoring_paralog_not_chosen_over_queried_gene(self):
+        """Edge (R7): a higher-scoring HGNC paralog must NOT beat the lower-scoring queried gene."""
+        rows = [
+            _row("NCBIGene:7133", 4.5, "TNFRSF1B", ["NCBIGene", "HGNC"]),  # paralog, higher score
+            _row("NCBIGene:7132", 2.4, "TNFRSF1A", ["NCBIGene", "HGNC"]),  # queried gene
+        ]
+        chosen = select(rows, "TNFRSF1A", prefer_human=True)
+        assert chosen is not None
+        assert chosen["id"] == "NCBIGene:7132"
+
+    def test_no_hgnc_falls_back_to_top_score(self):
+        """Edge: no HGNC-bearing row -> honest fallback to the top-scored candidate."""
+        rows = [
+            _row("NCBIGene:397020", 4.8, "TNFRSF1A", ["NCBIGene", "RGD"]),
+            _row("NCBIGene:406471", 3.3, "tnfrsf1a", ["NCBIGene", "ZFIN"]),
+        ]
+        chosen = select(rows, "TNFRSF1A", prefer_human=True)
+        assert chosen is not None
+        assert chosen["id"] == "NCBIGene:397020"
+
+    def test_alias_query_still_picks_human(self):
+        """Edge: HGNC row exists but its name doesn't equal the (alias) query -> best human, not ortholog."""
+        rows = [
+            _row("NCBIGene:397020", 4.8, "TNFRSF1A", ["NCBIGene", "RGD"]),  # ortholog, top score
+            _row("NCBIGene:7132", 2.4, "TNFRSF1A", ["NCBIGene", "HGNC"], synonyms=["TNFR1", "CD120a"]),
+        ]
+        chosen = select(rows, "CD120a", prefer_human=True)
+        assert chosen is not None
+        assert chosen["id"] == "NCBIGene:7132"
+
+    def test_prefer_human_false_returns_top_score(self):
+        """Edge: prefer_human disabled -> legacy top-1 behavior regardless of HGNC."""
+        chosen = select(TNFRSF1A_ROWS, "TNFRSF1A", prefer_human=False)
+        assert chosen is not None
+        assert chosen["id"] == "NCBIGene:397020"
+
+    def test_empty_candidate_list_returns_none(self):
+        """Edge: empty list -> None, no exception."""
+        assert select([], "TNFRSF1A", prefer_human=True) is None
+
+    def test_missing_keys_do_not_raise(self):
+        """Edge: rows missing `prefixes`/`score` keys are tolerated (treated as non-human, fallback)."""
+        rows = [{"id": "NCBIGene:1", "name": "X"}, {"id": "NCBIGene:2", "name": "X", "score": 1.0}]
+        chosen = select(rows, "X", prefer_human=True)
+        assert chosen is not None
+        assert chosen["id"] == "NCBIGene:1"  # first row, honest fallback (no HGNC anywhere)

--- a/tests/test_prefer_human_threading.py
+++ b/tests/test_prefer_human_threading.py
@@ -1,0 +1,127 @@
+"""Tests for threading the `prefer_human` flag from the API options model down to the annotator.
+
+These cover the engine's category-applicability gate and the request-model contract without hitting
+the live Kestrel API or the (slow) Biolink Model Toolkit (the annotator's selection logic is covered
+in test_kestrel_hybrid_selection.py; the live gold-set is covered by the integration test).
+
+The Biolink client is stubbed so the gate logic is exercised hermetically -- no bmt init, no network.
+"""
+
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+
+from biomapper2.api.models.requests import MappingOptions
+from biomapper2.core.annotation_engine import AnnotationEngine
+
+HYBRID_SLUG = "kestrel-hybrid-search"
+
+
+def _fake_biolink():
+    """Stub BiolinkClient.get_descendants: reflexive, with Gene/Protein as their own (only) descendants."""
+    fake = MagicMock()
+    fake.get_descendants.side_effect = lambda c: {c}
+    return fake
+
+
+@pytest.fixture
+def engine():
+    """A real AnnotationEngine with a stubbed Biolink client (avoids the slow bmt initialization)."""
+    return AnnotationEngine(biolink_client=_fake_biolink())
+
+
+def _spy_single(engine: AnnotationEngine, monkeypatch) -> MagicMock:
+    """Spy the hybrid annotator's get_annotations (auto-restored after the test by monkeypatch)."""
+    spy = MagicMock(return_value={HYBRID_SLUG: {}})
+    monkeypatch.setattr(engine.annotator_registry[HYBRID_SLUG], "get_annotations", spy)
+    return spy
+
+
+def _spy_bulk(engine: AnnotationEngine, monkeypatch) -> MagicMock:
+    """Spy the hybrid annotator's get_annotations_bulk with an index-preserving return."""
+
+    def _return(entities, *_args, **_kwargs):
+        return pd.Series([{HYBRID_SLUG: {}} for _ in range(len(entities))], index=entities.index)
+
+    spy = MagicMock(side_effect=_return)
+    monkeypatch.setattr(engine.annotator_registry[HYBRID_SLUG], "get_annotations_bulk", spy)
+    return spy
+
+
+class TestMappingOptionsContract:
+    def test_prefer_human_defaults_true(self):
+        """Default-on (R4): an options object created without the field has prefer_human True."""
+        assert MappingOptions().prefer_human is True
+
+    def test_prefer_human_can_be_disabled(self):
+        assert MappingOptions(prefer_human=False).prefer_human is False
+
+    def test_unknown_extra_field_is_ignored(self):
+        """Backward-compat (R5): an unknown option from a newer client does not raise."""
+        opts = MappingOptions.model_validate({"prefer_human": True, "some_future_option": 123})
+        assert opts.prefer_human is True
+        assert not hasattr(opts, "some_future_option")
+
+
+class TestEngineApplicabilityGate:
+    def test_gene_category_receives_effective_true(self, engine, monkeypatch):
+        """Happy path: gene category + prefer_human=True -> annotator receives effective True."""
+        spy = _spy_single(engine, monkeypatch)
+        engine.annotate(
+            item=pd.Series({"name": "TNFRSF1A"}),
+            name_field="name",
+            provided_id_fields=[],
+            category="biolink:Gene",
+            prefixes=[],
+            mode="all",
+            annotators=[HYBRID_SLUG],
+            prefer_human=True,
+        )
+        assert spy.call_args.kwargs["prefer_human"] is True
+
+    def test_metabolite_category_receives_effective_false(self, engine, monkeypatch):
+        """Edge: metabolite category gates the flag off even when prefer_human=True is requested."""
+        spy = _spy_single(engine, monkeypatch)
+        engine.annotate(
+            item=pd.Series({"name": "glucose"}),
+            name_field="name",
+            provided_id_fields=[],
+            category="biolink:SmallMolecule",
+            prefixes=[],
+            mode="all",
+            annotators=[HYBRID_SLUG],
+            prefer_human=True,
+        )
+        assert spy.call_args.kwargs["prefer_human"] is False
+
+    def test_prefer_human_false_overrides_applicable_category(self, engine, monkeypatch):
+        """Edge: explicit opt-out yields effective False even for an applicable gene category."""
+        spy = _spy_single(engine, monkeypatch)
+        engine.annotate(
+            item=pd.Series({"name": "TNFRSF1A"}),
+            name_field="name",
+            provided_id_fields=[],
+            category="biolink:Gene",
+            prefixes=[],
+            mode="all",
+            annotators=[HYBRID_SLUG],
+            prefer_human=False,
+        )
+        assert spy.call_args.kwargs["prefer_human"] is False
+
+    def test_bulk_path_forwards_effective_flag(self, engine, monkeypatch):
+        """Integration (bulk gate): the DataFrame path forwards the effective flag to get_annotations_bulk."""
+        spy = _spy_bulk(engine, monkeypatch)
+        df = pd.DataFrame({"name": ["TNFRSF1A", "LDLR"]})
+        engine.annotate(
+            item=df,
+            name_field="name",
+            provided_id_fields=[],
+            category="biolink:Gene",
+            prefixes=[],
+            mode="all",
+            annotators=[HYBRID_SLUG],
+            prefer_human=True,
+        )
+        assert spy.call_args.kwargs["prefer_human"] is True


### PR DESCRIPTION
## HGNC human-preference re-ranking for gene/protein resolution

Promotes the feature reviewed and merged on the fork in trentleslie/biomapper2#5 (Greptile-reviewed; both findings addressed).

### Problem
For human genes/proteins, biomapper2 resolved a bare symbol to a **wrong-species ortholog** at `confidence_tier="high"` (e.g. `TNFRSF1A` → pig/rat `NCBIGene:397020` instead of human `NCBIGene:7132`). The hybrid-search annotator requested only the top-1 candidate; the human node typically ranks ~#4. This is the dominant failure behind kraken-chatbot's "false cold-start" problem.

### Fix
Default-on `prefer_human` re-ranking, gated to gene/protein categories:
1. Raise the candidate limit (`HYBRID_SEARCH_LIMIT=20`) **only for gene/protein** (metabolite/other payloads unchanged).
2. **Two-tier selection**: prefer the HGNC-bearing candidate matching the queried symbol (`name`/synonym) → else best human candidate → else top-scored fallback (honest miss, never fabricate). HGNC is a human-only marker already in the hybrid-search row `prefixes` — no extra Kestrel call.
3. Thread `prefer_human: bool = True` through the options model → all four routes → `Mapper` → `AnnotationEngine` (applicability gated via `get_descendants`, memoized) → annotator.

### ⚠️ Intended behavior change
Gene/protein resolution now prefers the **human** node by default for every caller — no client change required; `prefer_human=False` restores legacy top-1. **Metabolites unchanged.** Returned `primary_curie` values shift for affected genes — any downstream golden/snapshot tests pinning gene CURIEs will change.

### Validation
- Live-verified against prod Kestrel REST (2026-06-15): `TNFRSF1A→7132`, `TNFRSF1B→7133`, `LDLR→3949` recover the human node at rank #4.
- Unit tests: selection (8) + threading (7), all pass; ruff/black/pyright clean.
- `tests/test_human_gene_gold_set.py` is the live merge-gate (`@pytest.mark.integration`). **Must run in CI / a network-enabled env** — it couldn't complete in the authoring sandbox (bmt model init network-blocked there; Kestrel itself reachable).

### Known residual
`GH1`'s human node (`NCBIGene:2688`) is absent from Kestrel hybrid-search even at limit=50 — a Kestrel *recall* gap a re-rank can't fix. Captured as an `xfail(strict=False)` (auto-passes if Kestrel later indexes it) plus a graceful-fallback assertion. Worth raising with the Kestrel team separately.

### Follow-up (separate PR)
`../biomapper` Python client: expose the per-request `prefer_human` opt-out. Sequenced after this server change; the server fix is complete without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
