### PR TITLE
feat: curated gene-symbol fallback resolver for drug-conflated human genes

### DIFF
--- a/src/biomapper2/config.py
+++ b/src/biomapper2/config.py
@@ -52,3 +52,8 @@ HYBRID_SEARCH_LIMIT = 20
 # Human-only CURIE prefixes. HGNC assigns IDs only to human genes, so its presence in a hybrid-search
 # row's `prefixes` marks the human node. Any prefix added here must itself be human-exclusive.
 HUMAN_MARKER_PREFIXES = {"HGNC"}
+
+# Kill switch for the curated gene-symbol fallback bridge (see core/gene_symbol_resolver.py). When True
+# (default), gene/protein resolution misses for the curated drug-conflated symbols are resolved via the
+# deterministic non-search fallback. Set False to disable the bridge without a code revert.
+GENE_SYMBOL_FALLBACK_ENABLED = True

--- a/src/biomapper2/core/annotators/kestrel_hybrid.py
+++ b/src/biomapper2/core/annotators/kestrel_hybrid.py
@@ -3,14 +3,29 @@ from typing import Any, cast
 
 import pandas as pd
 
-from ...config import HUMAN_MARKER_PREFIXES, HYBRID_SEARCH_LIMIT, KESTREL_BATCH_SIZE_SEARCH
+from ...config import (
+    GENE_SYMBOL_FALLBACK_ENABLED,
+    HUMAN_MARKER_PREFIXES,
+    HYBRID_SEARCH_LIMIT,
+    KESTREL_BATCH_SIZE_SEARCH,
+)
 from ...utils import AssignedIDsDict, kestrel_request, text_is_not_empty
+from ..gene_symbol_resolver import GeneSymbolResolver
 from .base import BaseAnnotator
+
+# Score assigned to a node recovered by the deterministic symbol fallback. Modest and fixed: the result
+# is a verified identity match, but it bypassed competitive search, so it must not be reported as a top
+# search hit. The `resolved_via` provenance marker is the authoritative signal, not this score.
+_FALLBACK_SCORE = 1.0
 
 
 class KestrelHybridSearchAnnotator(BaseAnnotator):
 
     slug = "kestrel-hybrid-search"
+
+    def __init__(self) -> None:
+        # Annotator-owned resolver (arg-free construction preserves the registry pattern; no network here).
+        self._resolver = GeneSymbolResolver()
 
     def get_annotations(
         self,
@@ -41,12 +56,24 @@ class KestrelHybridSearchAnnotator(BaseAnnotator):
                 term_results = results[search_term]
 
             annotations: dict[str, dict[str, dict[str, Any]]] = {}
-            chosen = self._select_result(term_results, search_term, prefer_human)
+            chosen, matched = self._select_result(term_results, search_term, prefer_human)
+
+            # Miss path: no HGNC + exact-symbol match was found among the search rows (ortholog fallback,
+            # empty results, or a best-HGNC paralog). For the curated drug-conflated symbols, the human
+            # node is unreachable by search, so resolve it deterministically (non-search) and verify.
+            if prefer_human and GENE_SYMBOL_FALLBACK_ENABLED and not matched:
+                resolved_curie = self._resolver.resolve(search_term)
+                if resolved_curie is not None:
+                    chosen = {"id": resolved_curie, "score": _FALLBACK_SCORE, "resolved_via": "symbol_fallback"}
+
             if chosen is not None:
                 node_id = chosen["id"]
                 score = chosen["score"]
                 vocab, local_id = node_id.split(":", 1)
-                annotations.setdefault(vocab, {})[local_id] = {"score": score}
+                metadata: dict[str, Any] = {"score": score}
+                if chosen.get("resolved_via"):
+                    metadata["resolved_via"] = chosen["resolved_via"]
+                annotations.setdefault(vocab, {})[local_id] = metadata
 
             return {self.slug: annotations}
         else:
@@ -89,31 +116,39 @@ class KestrelHybridSearchAnnotator(BaseAnnotator):
     # ----------------------------------------- Helper methods ----------------------------------------------- #
 
     @staticmethod
-    def _select_result(term_results: list[dict] | None, search_term: str, prefer_human: bool) -> dict | None:
-        """Select one candidate row from a hybrid-search result list.
+    def _select_result(
+        term_results: list[dict] | None, search_term: str, prefer_human: bool
+    ) -> tuple[dict | None, bool]:
+        """Select one candidate row, and report whether it is a genuine human-gene match.
+
+        Returns ``(chosen_row, matched)`` where ``matched`` is True only when ``chosen_row`` is an
+        HGNC-bearing row that exact-symbol-matches the query. ``matched`` is False for an empty result,
+        the legacy top-1, the ortholog fallback, and the best-HGNC-but-no-symbol-match (paralog) case —
+        all of which the caller treats as a miss eligible for the deterministic symbol fallback.
 
         Two-tier human preference (finalized from the 2026-06-15 live spike):
         1. Filter to human (HGNC-bearing) rows; if none, fall back to the top-scored candidate.
-        2. Among human rows, prefer those whose symbol matches the query (``name`` or a synonym);
-           if none match, keep all human rows (avoids over-rejecting alias queries to an ortholog).
-        3. Return the highest-scoring row of that pool.
+        2. Among human rows, prefer those whose symbol matches the query (``name`` or a synonym). A
+           symbol-matched pick is the only genuine "match"; the no-symbol-match fallback is not.
+        3. Return the highest-scoring row of the chosen pool.
 
         The HGNC filter must precede the symbol match because orthologs share the human row's ``name``
         (same symbol, different species) — HGNC separates species, the symbol match picks the right gene.
-        Returns None for an empty/None result list.
         """
         if not term_results:
-            return None
+            return None, False
         if not prefer_human:
-            return term_results[0]
+            return term_results[0], False
 
         human = [r for r in term_results if HUMAN_MARKER_PREFIXES & set(r.get("prefixes") or [])]
         if not human:
-            return term_results[0]
+            return term_results[0], False
 
         exact = [r for r in human if KestrelHybridSearchAnnotator._symbol_matches(r, search_term)]
-        pool = exact if exact else human
-        return max(pool, key=lambda r: r.get("score", 0))
+        if exact:
+            return max(exact, key=lambda r: r.get("score", 0)), True
+        # HGNC rows exist but none symbol-match the query (e.g. a paralog) — not a genuine match.
+        return max(human, key=lambda r: r.get("score", 0)), False
 
     @staticmethod
     def _symbol_matches(row: dict, search_term: str) -> bool:

--- a/src/biomapper2/core/gene_symbol_resolver.py
+++ b/src/biomapper2/core/gene_symbol_resolver.py
@@ -1,0 +1,73 @@
+"""Curated, non-search fallback for human gene nodes that Kestrel search cannot surface.
+
+A small set of human genes whose protein product is a marketed therapeutic are conflated by the
+upstream Translator/Babel layer into a single node named for the drug (e.g. GH1 -> the SOMATROPIN
+node). The node still carries the gene symbol as a synonym and an HGNC equivalent, but it never ranks
+for the gene symbol in any Kestrel search modality, so `prefer_human` re-ranking can never reach it.
+
+This resolver is a deterministic, non-search bridge: for the curated symbols only, it returns the
+canonical human NCBIGene CURIE, accepting it only after `/get-nodes` confirms the node carries the
+queried symbol as a synonym AND an HGNC equivalent (so it cannot inject a wrong-but-human gene). It is
+a no-op for every other symbol. This is a temporary measure; the durable fix is upstream (Kestrel-side
+exact-symbol retrieval / de-conflation). See docs/plans/2026-06-17-001-feat-gene-symbol-fallback-resolver-plan.md.
+"""
+
+from ..config import KESTREL_BATCH_SIZE_CANONICALIZE
+from ..utils import kestrel_request
+
+# Verified 2026-06-16: each of these human gene nodes carries its gene symbol as a synonym and an
+# HGNC equivalent, yet is unreachable by symbol across hybrid/text/vector search (drug-conflation).
+CURATED_GENE_SYMBOL_TO_CURIE = {
+    "GH1": "NCBIGene:2688",
+    "CALCA": "NCBIGene:796",
+    "POMC": "NCBIGene:5443",
+    "CRH": "NCBIGene:1392",
+    "CTLA4": "NCBIGene:1493",
+    "GBA1": "NCBIGene:2629",
+}
+
+# Case-folded lookup so queries match regardless of case.
+_CURATED = {symbol.casefold(): curie for symbol, curie in CURATED_GENE_SYMBOL_TO_CURIE.items()}
+
+
+class GeneSymbolResolver:
+    """Resolve a curated gene symbol to its HGNC-verified human NCBIGene CURIE (or None)."""
+
+    def resolve(self, symbol: str | None) -> str | None:
+        """Return the canonical human NCBIGene CURIE for a curated symbol, else None.
+
+        Returns None (a no-op) for any non-curated symbol, and rejects a curated symbol whose node
+        does not carry the queried symbol as a synonym or lacks an HGNC equivalent — never fabricates
+        and never returns a different human gene.
+        """
+        if not symbol:
+            return None
+        key = str(symbol).strip().casefold()
+        curie = _CURATED.get(key)
+        if curie is None:
+            return None  # no-op for everything outside the curated set
+
+        try:
+            nodes = kestrel_request(
+                method="POST",
+                endpoint="get-nodes",
+                batch_field="curies",
+                batch_items=[curie],
+                batch_size=KESTREL_BATCH_SIZE_CANONICALIZE,
+                json={"slim": False, "truncate_long_fields": False},
+            )
+        except Exception:
+            return None  # honest fallback on any Kestrel error
+
+        node = nodes.get(curie) if isinstance(nodes, dict) else None
+        if not isinstance(node, dict):
+            return None
+
+        # Verify identity (queried symbol present as a synonym), not just humanity (HGNC present).
+        synonyms = {str(s).strip().casefold() for s in (node.get("synonyms") or [])}
+        if key not in synonyms:
+            return None
+        if not any(str(e).startswith("HGNC:") for e in (node.get("equivalent_ids") or [])):
+            return None
+
+        return curie

--- a/src/biomapper2/core/gene_symbol_resolver.py
+++ b/src/biomapper2/core/gene_symbol_resolver.py
@@ -12,6 +12,8 @@ a no-op for every other symbol. This is a temporary measure; the durable fix is 
 exact-symbol retrieval / de-conflation). See docs/plans/2026-06-17-001-feat-gene-symbol-fallback-resolver-plan.md.
 """
 
+import logging
+
 from ..config import HUMAN_MARKER_PREFIXES, KESTREL_BATCH_SIZE_CANONICALIZE
 from ..utils import kestrel_request
 
@@ -42,8 +44,8 @@ class GeneSymbolResolver:
         """Return the canonical human NCBIGene CURIE for a curated symbol, else None.
 
         Returns None (a no-op) for any non-curated symbol, and rejects a curated symbol whose node
-        does not carry the queried symbol as a synonym or lacks an HGNC equivalent — never fabricates
-        and never returns a different human gene.
+        does not carry the queried symbol (as its name or a synonym) or lacks an HGNC equivalent —
+        never fabricates and never returns a different human gene.
         """
         if not symbol:
             return None
@@ -61,16 +63,25 @@ class GeneSymbolResolver:
                 batch_size=KESTREL_BATCH_SIZE_CANONICALIZE,
                 json={"slim": False, "truncate_long_fields": False},
             )
-        except Exception:
+        except Exception as exc:
+            # Network errors are already logged + re-raised upstream by the request layer; this guard
+            # exists for non-network failures (e.g. a malformed response body). Log so a curated gene
+            # silently ceasing to resolve leaves a diagnostic trace instead of vanishing.
+            logging.warning(f"gene-symbol fallback: get-nodes failed for {curie} ({symbol!r}): {exc}")
             return None  # honest fallback on any Kestrel error
 
         node = nodes.get(curie) if isinstance(nodes, dict) else None
         if not isinstance(node, dict):
             return None
 
-        # Verify identity (queried symbol present as a synonym), not just humanity (HGNC present).
-        synonyms = {str(s).strip().casefold() for s in (node.get("synonyms") or [])}
-        if key not in synonyms:
+        # Verify identity (queried symbol present on the node), not just humanity (HGNC present). Match
+        # on the node `name` OR a synonym, mirroring _select_result._symbol_matches so the two identity
+        # checks cannot diverge: today the curated nodes are drug-named with the symbol in `synonyms`,
+        # but if upstream de-conflation moves the symbol back into `name`, accepting either keeps the
+        # guard correct instead of silently rejecting a now-corrected node.
+        identity = {str(s).strip().casefold() for s in (node.get("synonyms") or [])}
+        identity.add(str(node.get("name", "")).strip().casefold())
+        if key not in identity:
             return None
         # Match on the CURIE prefix, case-insensitively, against the shared human-marker set — a
         # case-sensitive `startswith("HGNC:")` would silently reject a node whose equivalent ids

--- a/src/biomapper2/core/gene_symbol_resolver.py
+++ b/src/biomapper2/core/gene_symbol_resolver.py
@@ -12,8 +12,13 @@ a no-op for every other symbol. This is a temporary measure; the durable fix is 
 exact-symbol retrieval / de-conflation). See docs/plans/2026-06-17-001-feat-gene-symbol-fallback-resolver-plan.md.
 """
 
-from ..config import KESTREL_BATCH_SIZE_CANONICALIZE
+from ..config import HUMAN_MARKER_PREFIXES, KESTREL_BATCH_SIZE_CANONICALIZE
 from ..utils import kestrel_request
+
+# Case-folded human-marker prefixes, matched against the prefix of each equivalent id. Reuses the
+# single source of truth in config (the same set _select_result uses) so the two human-gate paths
+# cannot drift, and is case-insensitive to tolerate lower-cased CURIE prefixes from the KG.
+_HUMAN_MARKER_PREFIXES_CF = {p.casefold() for p in HUMAN_MARKER_PREFIXES}
 
 # Verified 2026-06-16: each of these human gene nodes carries its gene symbol as a synonym and an
 # HGNC equivalent, yet is unreachable by symbol across hybrid/text/vector search (drug-conflation).
@@ -67,7 +72,13 @@ class GeneSymbolResolver:
         synonyms = {str(s).strip().casefold() for s in (node.get("synonyms") or [])}
         if key not in synonyms:
             return None
-        if not any(str(e).startswith("HGNC:") for e in (node.get("equivalent_ids") or [])):
+        # Match on the CURIE prefix, case-insensitively, against the shared human-marker set — a
+        # case-sensitive `startswith("HGNC:")` would silently reject a node whose equivalent ids
+        # arrive lower-cased (e.g. "hgnc:4261"), dropping a genuinely human curated gene.
+        if not any(
+            str(e).split(":", 1)[0].strip().casefold() in _HUMAN_MARKER_PREFIXES_CF
+            for e in (node.get("equivalent_ids") or [])
+        ):
             return None
 
         return curie

--- a/tests/test_gene_symbol_resolver.py
+++ b/tests/test_gene_symbol_resolver.py
@@ -1,0 +1,53 @@
+"""Unit tests for the curated gene-symbol fallback resolver.
+
+The resolver is a no-op for non-curated symbols, and for the curated six it accepts the canonical
+human NCBIGene CURIE only after /get-nodes confirms the node carries the queried symbol as a synonym
+AND an HGNC equivalent. All Kestrel access is mocked so these run offline.
+"""
+
+from unittest.mock import patch
+
+from biomapper2.core.gene_symbol_resolver import GeneSymbolResolver
+
+
+def _node(synonyms, equivalent_ids):
+    return {"synonyms": synonyms, "equivalent_ids": equivalent_ids}
+
+
+class TestGeneSymbolResolver:
+    @patch("biomapper2.core.gene_symbol_resolver.kestrel_request")
+    def test_resolves_curated_with_symbol_synonym_and_hgnc(self, mock_req):
+        mock_req.return_value = {"NCBIGene:2688": _node(["SOMATROPIN", "GH1", "GHN"], ["NCBIGene:2688", "HGNC:4261"])}
+        assert GeneSymbolResolver().resolve("GH1") == "NCBIGene:2688"
+
+    @patch("biomapper2.core.gene_symbol_resolver.kestrel_request")
+    def test_case_insensitive_symbol(self, mock_req):
+        mock_req.return_value = {"NCBIGene:1493": _node(["BELATACEPT", "CTLA4"], ["HGNC:2505"])}
+        assert GeneSymbolResolver().resolve("ctla4") == "NCBIGene:1493"
+
+    @patch("biomapper2.core.gene_symbol_resolver.kestrel_request")
+    def test_non_curated_symbol_is_noop(self, mock_req):
+        """A symbol outside the curated six returns None without ever calling Kestrel."""
+        assert GeneSymbolResolver().resolve("TP53") is None
+        mock_req.assert_not_called()
+
+    @patch("biomapper2.core.gene_symbol_resolver.kestrel_request")
+    def test_rejects_when_node_lacks_queried_symbol(self, mock_req):
+        """Curated symbol but the node does not carry it as a synonym -> reject (guards wrong/stale gene)."""
+        mock_req.return_value = {"NCBIGene:2688": _node(["SOMATROPIN", "Norditropin"], ["HGNC:4261"])}
+        assert GeneSymbolResolver().resolve("GH1") is None
+
+    @patch("biomapper2.core.gene_symbol_resolver.kestrel_request")
+    def test_rejects_when_node_lacks_hgnc(self, mock_req):
+        mock_req.return_value = {"NCBIGene:2688": _node(["SOMATROPIN", "GH1"], ["NCBIGene:2688", "UNII:X"])}
+        assert GeneSymbolResolver().resolve("GH1") is None
+
+    @patch("biomapper2.core.gene_symbol_resolver.kestrel_request")
+    def test_get_nodes_error_returns_none(self, mock_req):
+        mock_req.side_effect = RuntimeError("kestrel down")
+        assert GeneSymbolResolver().resolve("GH1") is None
+
+    @patch("biomapper2.core.gene_symbol_resolver.kestrel_request")
+    def test_node_absent_returns_none(self, mock_req):
+        mock_req.return_value = {}  # curie not in KG
+        assert GeneSymbolResolver().resolve("GBA1") is None

--- a/tests/test_gene_symbol_resolver.py
+++ b/tests/test_gene_symbol_resolver.py
@@ -43,6 +43,12 @@ class TestGeneSymbolResolver:
         assert GeneSymbolResolver().resolve("GH1") is None
 
     @patch("biomapper2.core.gene_symbol_resolver.kestrel_request")
+    def test_accepts_lowercase_hgnc_prefix(self, mock_req):
+        """The HGNC marker is matched case-insensitively, so a lower-cased prefix still verifies."""
+        mock_req.return_value = {"NCBIGene:2688": _node(["SOMATROPIN", "GH1"], ["NCBIGene:2688", "hgnc:4261"])}
+        assert GeneSymbolResolver().resolve("GH1") == "NCBIGene:2688"
+
+    @patch("biomapper2.core.gene_symbol_resolver.kestrel_request")
     def test_get_nodes_error_returns_none(self, mock_req):
         mock_req.side_effect = RuntimeError("kestrel down")
         assert GeneSymbolResolver().resolve("GH1") is None

--- a/tests/test_gene_symbol_resolver.py
+++ b/tests/test_gene_symbol_resolver.py
@@ -43,6 +43,13 @@ class TestGeneSymbolResolver:
         assert GeneSymbolResolver().resolve("GH1") is None
 
     @patch("biomapper2.core.gene_symbol_resolver.kestrel_request")
+    def test_accepts_symbol_as_node_name(self, mock_req):
+        """Symbol carried in `name` (not synonyms) still verifies — robust to upstream de-conflation."""
+        node = {"name": "GH1", "synonyms": ["growth hormone 1"], "equivalent_ids": ["HGNC:4261"]}
+        mock_req.return_value = {"NCBIGene:2688": node}
+        assert GeneSymbolResolver().resolve("GH1") == "NCBIGene:2688"
+
+    @patch("biomapper2.core.gene_symbol_resolver.kestrel_request")
     def test_accepts_lowercase_hgnc_prefix(self, mock_req):
         """The HGNC marker is matched case-insensitively, so a lower-cased prefix still verifies."""
         mock_req.return_value = {"NCBIGene:2688": _node(["SOMATROPIN", "GH1"], ["NCBIGene:2688", "hgnc:4261"])}

--- a/tests/test_human_gene_gold_set.py
+++ b/tests/test_human_gene_gold_set.py
@@ -1,10 +1,14 @@
 """Live merge-gate validation: human genes/proteins must resolve to the human node, not an ortholog.
 
 Marked `integration` (hits the live Kestrel API). Runs the full pipeline via Mapper.map_entity_to_kg
-with the default-on prefer_human behavior, asserts each positive gold entity resolves to the expected
-human NCBIGene carrying an HGNC marker, and persists a timestamped report (per the experiment-artifact
-SOP). GH1 is a negative control: its human node is absent from Kestrel hybrid-search even at limit=50
-(verified 2026-06-15), so it is expected to fall back gracefully and is counted in the fallback fraction.
+with the default-on prefer_human behavior, asserts each gold entity resolves to the expected human
+NCBIGene carrying an HGNC marker, and persists a timestamped report (per the experiment-artifact SOP).
+
+Two classes of positive case:
+- Search-recoverable (TNFRSF1A/TNFRSF1B/LDLR): the human node is in the candidate set and `prefer_human`
+  re-ranking selects it. The TNFRSF1A/TNFRSF1B pair exercises the paralog guard.
+- Drug-conflated (GH1/CALCA/POMC/CRH/CTLA4/GBA1): the human node is unreachable by any Kestrel search
+  (conflated into a drug node), so it resolves only via the curated gene-symbol fallback bridge.
 """
 
 import json
@@ -14,15 +18,20 @@ import pytest
 
 from biomapper2.config import PROJECT_ROOT
 
-# Positive cases: must resolve to the expected human NCBIGene (verified at rank ~#4 in the Unit 1 spike).
-# Includes a paralog pair (TNFRSF1A/TNFRSF1B) to exercise the R7 wrong-paralog guard against live data.
+# All gold entities must resolve to the expected human NCBIGene carrying an HGNC marker.
 POSITIVE_GOLD = {
+    # Search-recoverable (prefer_human re-ranking); includes a paralog pair (R7 guard).
     "TNFRSF1A": "NCBIGene:7132",
     "TNFRSF1B": "NCBIGene:7133",
     "LDLR": "NCBIGene:3949",
+    # Drug-conflated: unreachable by search, resolved via the curated symbol fallback bridge.
+    "GH1": "NCBIGene:2688",
+    "CALCA": "NCBIGene:796",
+    "POMC": "NCBIGene:5443",
+    "CRH": "NCBIGene:1392",
+    "CTLA4": "NCBIGene:1493",
+    "GBA1": "NCBIGene:2629",
 }
-# Negative control: human node absent from Kestrel candidates -> expected to fall back (Kestrel recall gap).
-NEGATIVE_CONTROL = {"GH1": "NCBIGene:2688"}
 
 
 def _has_hgnc(result: dict) -> bool:
@@ -43,7 +52,7 @@ def _map_gene(shared_mapper, name: str) -> dict:
 def gold_set_run(shared_mapper):
     """Run the full gold set live once, persist a timestamped report, and return the per-entity results."""
     rows = []
-    for name, expected in {**POSITIVE_GOLD, **NEGATIVE_CONTROL}.items():
+    for name, expected in POSITIVE_GOLD.items():
         result = _map_gene(shared_mapper, name)
         chosen = result.get("chosen_kg_id")
         rows.append(
@@ -88,35 +97,15 @@ class TestHumanGeneGoldSet:
         assert row["chosen_kg_id"] == POSITIVE_GOLD[name], f"{name} -> {row['chosen_kg_id']} (expected human)"
         assert row["has_hgnc"], f"{name} resolved node lacks an HGNC marker"
 
-    def test_gh1_negative_control_falls_back_gracefully(self, gold_set_run):
-        """GH1's human gene node is unreachable by symbol in Kestrel -> pipeline must return a node, not crash.
-
-        This asserts only graceful behavior (a node is chosen), which holds whether or not the upstream
-        Kestrel/Translator data issue is ever fixed -- so it is NOT brittle.
-        """
-        row = next(r for r in gold_set_run["rows"] if r["name"] == "GH1")
-        assert row["chosen_kg_id"] is not None  # graceful fallback (honest miss), no exception
-
-    @pytest.mark.xfail(
-        reason=(
-            "Upstream Translator/Kestrel entity-conflation, NOT a biomapper2 bug or a simple recall gap: "
-            "NCBIGene:2688 exists but is an over-merged clique whose preferred name is 'SOMATROPIN' "
-            "(recombinant hGH drug) with only pharmaceutical synonyms and no 'GH1' gene-symbol text, so "
-            "no search mode (text/vector/hybrid) retrieves it by 'GH1' even at limit=50 (verified live "
-            "2026-06-16). This is the documented Babel/NodeNormalization GeneProtein + DrugChemical "
-            "conflation collapsing GH1 gene -> growth-hormone protein -> somatropin drug into one node. "
-            "xfail (strict=False) documents it without blocking CI; auto-passes (xpass) if the KG node is "
-            "corrected upstream -- a Kestrel/Translator data fix, not a biomapper2 one."
-        ),
-        strict=False,
-    )
-    def test_gh1_should_resolve_to_human_when_upstream_conflation_fixed(self, gold_set_run):
-        """Records the desired GH1 outcome; xfails today, xpasses if the upstream conflation is corrected."""
-        row = next(r for r in gold_set_run["rows"] if r["name"] == "GH1")
-        assert row["chosen_kg_id"] == NEGATIVE_CONTROL["GH1"]
+    def test_drug_conflated_resolves_via_fallback(self, gold_set_run):
+        """The drug-conflated genes (unreachable by any Kestrel search) resolve via the curated bridge."""
+        for name in ("GH1", "CALCA", "POMC", "CRH", "CTLA4", "GBA1"):
+            row = next(r for r in gold_set_run["rows"] if r["name"] == name)
+            assert row["chosen_kg_id"] == POSITIVE_GOLD[name], f"{name} -> {row['chosen_kg_id']} (expected human)"
+            assert row["has_hgnc"], f"{name} resolved node lacks an HGNC marker"
 
     def test_fallback_fraction_reported(self, gold_set_run):
         """The run quantifies and persists the fallback fraction (R8 observability)."""
         assert 0.0 <= gold_set_run["fallback_fraction"] <= 1.0
-        # All positives should resolve; only the negative control is expected to fall back.
+        # With the curated fallback bridge in place, every gold gene should resolve to its human node.
         assert gold_set_run["n_positive_resolved"] == gold_set_run["n_positive"]

--- a/tests/test_human_gene_gold_set.py
+++ b/tests/test_human_gene_gold_set.py
@@ -34,9 +34,29 @@ POSITIVE_GOLD = {
 }
 
 
+# Slug of the annotator that owns the symbol-fallback bridge (see core/annotators/kestrel_hybrid.py).
+HYBRID_SLUG = "kestrel-hybrid-search"
+
+
 def _has_hgnc(result: dict) -> bool:
     """True if the resolved node carries an HGNC marker in its equivalent ids."""
     return "HGNC" in json.dumps(result.get("kg_equivalent_ids", {}))
+
+
+def _resolved_via(result: dict) -> str | None:
+    """Provenance marker for an assigned id, read from the preserved per-annotator ``assigned_ids``.
+
+    The symbol-fallback bridge tags its assigned id with ``resolved_via='symbol_fallback'``. That
+    marker is retained on the entity's ``assigned_ids`` (and surfaced in the API response) even though
+    the normalized curie/resolution layers do not carry it — so the gold-set can measure *actual*
+    bridge usage rather than inferring it from a chosen-id mismatch.
+    """
+    assigned = result.get("assigned_ids", {}) or {}
+    for vocab_map in (assigned.get(HYBRID_SLUG, {}) or {}).values():
+        for meta in (vocab_map or {}).values():
+            if isinstance(meta, dict) and meta.get("resolved_via"):
+                return str(meta["resolved_via"])
+    return None
 
 
 def _map_gene(shared_mapper, name: str) -> dict:
@@ -62,19 +82,23 @@ def gold_set_run(shared_mapper):
                 "chosen_kg_id": chosen,
                 "is_expected_human": chosen == expected,
                 "has_hgnc": _has_hgnc(result),
+                "resolved_via": _resolved_via(result),
                 "is_positive": name in POSITIVE_GOLD,
             }
         )
 
     positives = [r for r in rows if r["is_positive"]]
-    fell_back = [r for r in rows if not r["is_expected_human"]]
+    # Fraction of entities resolved through the curated symbol-fallback bridge (read from the
+    # preserved provenance marker, not inferred from a chosen-id mismatch) — the real R8 signal.
+    via_bridge = [r for r in rows if r["resolved_via"] == "symbol_fallback"]
     report = {
         "generated_utc": datetime.now(timezone.utc).isoformat(),
         "prefer_human": True,
         "n_total": len(rows),
         "n_positive": len(positives),
         "n_positive_resolved": sum(r["is_expected_human"] for r in positives),
-        "fallback_fraction": round(len(fell_back) / len(rows), 3),
+        "n_resolved_via_bridge": len(via_bridge),
+        "fallback_fraction": round(len(via_bridge) / len(rows), 3),
         "rows": rows,
     }
 
@@ -98,14 +122,22 @@ class TestHumanGeneGoldSet:
         assert row["has_hgnc"], f"{name} resolved node lacks an HGNC marker"
 
     def test_drug_conflated_resolves_via_fallback(self, gold_set_run):
-        """The drug-conflated genes (unreachable by any Kestrel search) resolve via the curated bridge."""
+        """The drug-conflated genes (unreachable by any Kestrel search) resolve via the curated bridge.
+
+        Asserts both the outcome (correct human node) AND the mechanism (the provenance marker proves
+        the bridge fired) — so a future regression where search starts surfacing these by coincidence
+        cannot pass this test silently.
+        """
         for name in ("GH1", "CALCA", "POMC", "CRH", "CTLA4", "GBA1"):
             row = next(r for r in gold_set_run["rows"] if r["name"] == name)
             assert row["chosen_kg_id"] == POSITIVE_GOLD[name], f"{name} -> {row['chosen_kg_id']} (expected human)"
             assert row["has_hgnc"], f"{name} resolved node lacks an HGNC marker"
+            assert row["resolved_via"] == "symbol_fallback", f"{name} did not resolve via the curated bridge"
 
     def test_fallback_fraction_reported(self, gold_set_run):
-        """The run quantifies and persists the fallback fraction (R8 observability)."""
+        """The run quantifies and persists how often the bridge fired (R8 observability)."""
         assert 0.0 <= gold_set_run["fallback_fraction"] <= 1.0
         # With the curated fallback bridge in place, every gold gene should resolve to its human node.
         assert gold_set_run["n_positive_resolved"] == gold_set_run["n_positive"]
+        # The fraction is read from real provenance: exactly the six drug-conflated genes use the bridge.
+        assert gold_set_run["n_resolved_via_bridge"] == 6

--- a/tests/test_kestrel_hybrid_fallback.py
+++ b/tests/test_kestrel_hybrid_fallback.py
@@ -1,0 +1,83 @@
+"""Tests for the gene-symbol fallback wiring in the hybrid annotator.
+
+These exercise the real `_select_result` (so the miss/match signal is validated, not mocked) and a
+mocked resolver, via the annotator's cache path so no Kestrel search call is made.
+"""
+
+from unittest.mock import MagicMock
+
+from biomapper2.core.annotators.kestrel_hybrid import KestrelHybridSearchAnnotator
+
+
+def _row(node_id, score, name, prefixes):
+    return {"id": node_id, "score": score, "name": name, "prefixes": prefixes}
+
+
+def _annotate(rows, term, prefer_human=True, resolver_returns: str | None = "NCBIGene:2688"):
+    """Run get_annotations via the cache path with a mocked resolver; return (assigned, resolver_mock)."""
+    ann = KestrelHybridSearchAnnotator()
+    ann._resolver = MagicMock()
+    ann._resolver.resolve.return_value = resolver_returns
+    assigned = ann.get_annotations(
+        {"name": term}, "name", "biolink:Gene", prefer_human=prefer_human, cache={term: rows}
+    )
+    return assigned[ann.slug], ann._resolver
+
+
+class TestFallbackWiring:
+    def test_ortholog_miss_uses_resolver(self):
+        """Only a non-HGNC ortholog returned -> resolver fires -> resolved human node chosen."""
+        rows = [_row("NCBIGene:403795", 4.8, "GH1", ["NCBIGene", "RGD"])]
+        annotations, resolver = _annotate(rows, "GH1")
+        assert "2688" in annotations.get("NCBIGene", {})
+        assert "403795" not in annotations.get("NCBIGene", {})
+        resolver.resolve.assert_called_once_with("GH1")
+        assert annotations["NCBIGene"]["2688"].get("resolved_via") == "symbol_fallback"
+
+    def test_paralog_hgnc_no_symbol_match_uses_resolver(self):
+        """Real _select_result returns a higher-scoring HGNC paralog (no symbol match) -> still a miss."""
+        rows = [
+            _row("NCBIGene:7133", 4.5, "TNFRSF1B", ["NCBIGene", "HGNC"]),  # HGNC but wrong gene
+            _row("NCBIGene:403795", 3.0, "GH1", ["NCBIGene", "RGD"]),
+        ]
+        annotations, resolver = _annotate(rows, "GH1")  # query GH1; no row symbol-matches GH1
+        resolver.resolve.assert_called_once_with("GH1")
+        assert "2688" in annotations.get("NCBIGene", {})
+        assert "7133" not in annotations.get("NCBIGene", {})
+
+    def test_genuine_hit_skips_resolver(self):
+        """An HGNC row that exact-symbol-matches the query is a hit -> resolver not called."""
+        rows = [
+            _row("NCBIGene:403795", 4.8, "GH1", ["NCBIGene", "RGD"]),  # ortholog, top score
+            _row("NCBIGene:2688", 2.4, "GH1", ["NCBIGene", "HGNC"]),  # human, HGNC + symbol match
+        ]
+        annotations, resolver = _annotate(rows, "GH1")
+        resolver.resolve.assert_not_called()
+        assert "2688" in annotations.get("NCBIGene", {})
+        assert "resolved_via" not in annotations["NCBIGene"]["2688"]
+
+    def test_non_curated_miss_keeps_ortholog(self):
+        """Resolver returns None (non-curated symbol) -> honest ortholog fallback preserved."""
+        rows = [_row("NCBIGene:999", 4.8, "FOO", ["NCBIGene", "RGD"])]
+        annotations, resolver = _annotate(rows, "FOO", resolver_returns=None)
+        resolver.resolve.assert_called_once_with("FOO")
+        assert "999" in annotations.get("NCBIGene", {})
+
+    def test_prefer_human_false_skips_resolver(self):
+        rows = [_row("NCBIGene:403795", 4.8, "GH1", ["NCBIGene", "RGD"])]
+        annotations, resolver = _annotate(rows, "GH1", prefer_human=False)
+        resolver.resolve.assert_not_called()
+        assert "403795" in annotations.get("NCBIGene", {})
+
+    def test_fallback_disabled_skips_resolver(self, monkeypatch):
+        monkeypatch.setattr("biomapper2.core.annotators.kestrel_hybrid.GENE_SYMBOL_FALLBACK_ENABLED", False)
+        rows = [_row("NCBIGene:403795", 4.8, "GH1", ["NCBIGene", "RGD"])]
+        annotations, resolver = _annotate(rows, "GH1")
+        resolver.resolve.assert_not_called()
+        assert "403795" in annotations.get("NCBIGene", {})
+
+    def test_empty_results_uses_resolver(self):
+        """No candidates at all -> resolver attempted; if it resolves, that node is used."""
+        annotations, resolver = _annotate([], "GH1")
+        resolver.resolve.assert_called_once_with("GH1")
+        assert "2688" in annotations.get("NCBIGene", {})

--- a/tests/test_kestrel_hybrid_fallback.py
+++ b/tests/test_kestrel_hybrid_fallback.py
@@ -76,6 +76,18 @@ class TestFallbackWiring:
         resolver.resolve.assert_not_called()
         assert "403795" in annotations.get("NCBIGene", {})
 
+    def test_fallback_disabled_unreachable_node_degrades_gracefully(self, monkeypatch):
+        """Kill switch off + an unreachable curated node (no candidates) -> honest empty, no crash.
+
+        Guards the degradation path the kill switch promises: disabling the bridge must not raise, it
+        just yields no annotation for the otherwise-unreachable gene (replaces the deleted integration
+        negative-control test with a network-free unit equivalent).
+        """
+        monkeypatch.setattr("biomapper2.core.annotators.kestrel_hybrid.GENE_SYMBOL_FALLBACK_ENABLED", False)
+        annotations, resolver = _annotate([], "GH1")
+        resolver.resolve.assert_not_called()
+        assert annotations == {}
+
     def test_empty_results_uses_resolver(self):
         """No candidates at all -> resolver attempted; if it resolves, that node is used."""
         annotations, resolver = _annotate([], "GH1")

--- a/tests/test_kestrel_hybrid_selection.py
+++ b/tests/test_kestrel_hybrid_selection.py
@@ -27,7 +27,7 @@ TNFRSF1A_ROWS = [
 class TestSelectResult:
     def test_human_below_top_is_selected(self):
         """Happy path: HGNC-bearing human row (#4, lower score) chosen over top-scored ortholog."""
-        chosen = select(TNFRSF1A_ROWS, "TNFRSF1A", prefer_human=True)
+        chosen, _ = select(TNFRSF1A_ROWS, "TNFRSF1A", prefer_human=True)
         assert chosen is not None
         assert chosen["id"] == "NCBIGene:7132"
 
@@ -37,7 +37,7 @@ class TestSelectResult:
             _row("NCBIGene:7132", 4.9, "TNFRSF1A", ["NCBIGene", "HGNC", "ENSEMBL"]),
             _row("NCBIGene:397020", 4.8, "TNFRSF1A", ["NCBIGene", "RGD"]),
         ]
-        chosen = select(rows, "TNFRSF1A", prefer_human=True)
+        chosen, _ = select(rows, "TNFRSF1A", prefer_human=True)
         assert chosen is not None
         assert chosen["id"] == "NCBIGene:7132"
 
@@ -47,7 +47,7 @@ class TestSelectResult:
             _row("NCBIGene:7133", 4.5, "TNFRSF1B", ["NCBIGene", "HGNC"]),  # paralog, higher score
             _row("NCBIGene:7132", 2.4, "TNFRSF1A", ["NCBIGene", "HGNC"]),  # queried gene
         ]
-        chosen = select(rows, "TNFRSF1A", prefer_human=True)
+        chosen, _ = select(rows, "TNFRSF1A", prefer_human=True)
         assert chosen is not None
         assert chosen["id"] == "NCBIGene:7132"
 
@@ -57,7 +57,7 @@ class TestSelectResult:
             _row("NCBIGene:397020", 4.8, "TNFRSF1A", ["NCBIGene", "RGD"]),
             _row("NCBIGene:406471", 3.3, "tnfrsf1a", ["NCBIGene", "ZFIN"]),
         ]
-        chosen = select(rows, "TNFRSF1A", prefer_human=True)
+        chosen, _ = select(rows, "TNFRSF1A", prefer_human=True)
         assert chosen is not None
         assert chosen["id"] == "NCBIGene:397020"
 
@@ -67,23 +67,23 @@ class TestSelectResult:
             _row("NCBIGene:397020", 4.8, "TNFRSF1A", ["NCBIGene", "RGD"]),  # ortholog, top score
             _row("NCBIGene:7132", 2.4, "TNFRSF1A", ["NCBIGene", "HGNC"], synonyms=["TNFR1", "CD120a"]),
         ]
-        chosen = select(rows, "CD120a", prefer_human=True)
+        chosen, _ = select(rows, "CD120a", prefer_human=True)
         assert chosen is not None
         assert chosen["id"] == "NCBIGene:7132"
 
     def test_prefer_human_false_returns_top_score(self):
         """Edge: prefer_human disabled -> legacy top-1 behavior regardless of HGNC."""
-        chosen = select(TNFRSF1A_ROWS, "TNFRSF1A", prefer_human=False)
+        chosen, _ = select(TNFRSF1A_ROWS, "TNFRSF1A", prefer_human=False)
         assert chosen is not None
         assert chosen["id"] == "NCBIGene:397020"
 
     def test_empty_candidate_list_returns_none(self):
         """Edge: empty list -> None, no exception."""
-        assert select([], "TNFRSF1A", prefer_human=True) is None
+        assert select([], "TNFRSF1A", prefer_human=True)[0] is None
 
     def test_missing_keys_do_not_raise(self):
         """Edge: rows missing `prefixes`/`score` keys are tolerated (treated as non-human, fallback)."""
         rows = [{"id": "NCBIGene:1", "name": "X"}, {"id": "NCBIGene:2", "name": "X", "score": 1.0}]
-        chosen = select(rows, "X", prefer_human=True)
+        chosen, _ = select(rows, "X", prefer_human=True)
         assert chosen is not None
         assert chosen["id"] == "NCBIGene:1"  # first row, honest fallback (no HGNC anywhere)


### PR DESCRIPTION
## Summary

Some human genes whose protein product is a marketed therapeutic are conflated by the
upstream Translator/Babel layer into a single node named for the drug (e.g. GH1 -> the
SOMATROPIN node). The node still carries the gene symbol as a synonym and an HGNC
equivalent, but it never ranks for the gene symbol in any Kestrel search modality, so
`prefer_human` re-ranking can never reach it.

This adds a deterministic, non-search **fallback bridge**: for a curated set of six such
symbols (GH1, CALCA, POMC, CRH, CTLA4, GBA1), it returns the canonical human NCBIGene
CURIE -- but only after `/get-nodes` confirms the node carries the queried symbol (as its
name or a synonym) AND an HGNC equivalent, so it cannot inject a wrong-but-human gene. It
is a no-op for every other symbol. Gated to the `prefer_human` gene/protein miss path and
behind a `GENE_SYMBOL_FALLBACK_ENABLED` kill switch. **Temporary measure**; the durable
fix is upstream (Kestrel-side exact-symbol retrieval / de-conflation).

## Changes

- `core/gene_symbol_resolver.py` (new) -- curated symbol -> HGNC-verified human CURIE resolver
- `core/annotators/kestrel_hybrid.py` -- `_select_result` now reports a `matched` signal;
  the miss path consults the resolver and tags results with `resolved_via="symbol_fallback"`
- `config.py` -- `GENE_SYMBOL_FALLBACK_ENABLED` kill switch
- Tests: resolver unit tests, annotator wiring tests, gold-set integration coverage

## Review trail (stage 1 on the fork, PR trentleslie/biomapper2#6)

High-effort self-review + Greptile both ran on the fork before this upstream PR. Addressed:
- **Case-insensitive HGNC marker** matched against the shared `HUMAN_MARKER_PREFIXES`
  (a lower-cased CURIE prefix no longer silently rejects a curated gene)
- **Identity check accepts name OR synonym** (mirrors `_symbol_matches`; robust to upstream
  de-conflation that moves the symbol back into `name`)
- **Non-network get-nodes failures are now logged** before the honest `None` fallback
- **Real provenance-based observability** -- the gold-set reads `resolved_via` from the
  preserved `assigned_ids` to measure actual bridge usage, asserting the mechanism fired
- **Graceful-degradation guard** -- network-free unit test for kill-switch-off + unreachable node

### Known follow-ups (deferred)
- No automated tripwire to detect when upstream de-conflation lands (bridge can then retire)
- Per-row `/get-nodes` verification is un-batched/un-memoized in the bulk path
- Resolver overlaps `Linker.get_equivalent_ids` (`/get-nodes` contract in two places)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
