### PR TITLE
feat: canonical-namespace preference + gene gold-set fix (unblocks release CI)

### DIFF
--- a/src/biomapper2/api/models/requests.py
+++ b/src/biomapper2/api/models/requests.py
@@ -32,6 +32,16 @@ class MappingOptions(BaseModel):
             "top-scored selection. No effect on metabolites or other non-gene/protein categories."
         ),
     )
+    prefer_canonical: bool = Field(
+        default=True,
+        description=(
+            "For non-gene categories with a configured canonical-namespace policy (e.g. CHEBI/HMDB/RefMet "
+            "for metabolites, MONDO for disease), prefer the canonical-namespace node that matches the "
+            "query over a same-text node from a non-canonical vocabulary (UMLS/ICD/KEGG/...). Default True. "
+            "Set False to restore legacy top-scored selection. No effect on gene/protein (which use "
+            "prefer_human)."
+        ),
+    )
 
     # Ignore unknown fields so a newer client sending extra options to an older server does not 422.
     # (Pydantic v2 already defaults to ignore; set explicitly as documentation of the contract.)

--- a/src/biomapper2/api/routes/mapping.py
+++ b/src/biomapper2/api/routes/mapping.py
@@ -97,6 +97,7 @@ async def map_entity(
             annotation_mode=body.options.annotation_mode,
             annotators=body.options.annotators,
             prefer_human=body.options.prefer_human,
+            prefer_canonical=body.options.prefer_canonical,
         )
 
         result = extract_mapping_result(mapped_item, body.name)
@@ -165,6 +166,7 @@ async def map_batch(
                 annotation_mode=entity_req.options.annotation_mode,
                 annotators=entity_req.options.annotators,
                 prefer_human=entity_req.options.prefer_human,
+                prefer_canonical=entity_req.options.prefer_canonical,
             )
 
             result = extract_mapping_result(mapped_item, entity_req.name)
@@ -208,6 +210,7 @@ async def map_dataset(
     annotators: str | None = None,  # Comma-separated
     vocab: str | None = None,
     prefer_human: bool = True,
+    prefer_canonical: bool = True,
     _api_key: str = Depends(validate_api_key),
 ) -> DatasetMappingResponse:
     """
@@ -255,6 +258,7 @@ async def map_dataset(
             annotation_mode=annotation_mode,  # type: ignore
             annotators=annotator_list,
             prefer_human=prefer_human,
+            prefer_canonical=prefer_canonical,
         )
 
     except Exception as e:
@@ -284,6 +288,7 @@ async def map_dataset_stream(
     annotators: str | None = None,
     vocab: str | None = None,
     prefer_human: bool = True,
+    prefer_canonical: bool = True,
     _api_key: str = Depends(validate_api_key),
 ) -> StreamingResponse:
     """
@@ -330,6 +335,7 @@ async def map_dataset_stream(
                     annotation_mode=annotation_mode,  # type: ignore
                     annotators=annotator_list,
                     prefer_human=prefer_human,
+                    prefer_canonical=prefer_canonical,
                 )
 
                 result = {

--- a/src/biomapper2/config.py
+++ b/src/biomapper2/config.py
@@ -57,3 +57,17 @@ HUMAN_MARKER_PREFIXES = {"HGNC"}
 # (default), gene/protein resolution misses for the curated drug-conflated symbols are resolved via the
 # deterministic non-search fallback. Set False to disable the bridge without a code revert.
 GENE_SYMBOL_FALLBACK_ENABLED = True
+
+# Per-category preferred (canonical) namespace prefixes for the prefer_canonical re-ranking. Within a
+# Biolink category, hybrid-search ranks across all namespaces at once, so a non-canonical same-text node
+# (UMLS/ICD/KEGG/PANTHER) frequently outranks the canonical one. These prefixes mark the canonical node so
+# the annotator can prefer it (see core/annotators/kestrel_hybrid.py:_select_canonical). Keys are Biolink
+# categories; the engine expands each via get_descendants so subcategories inherit the policy. Gene/protein
+# are intentionally absent — they use HUMAN_MARKER_PREFIXES / prefer_human instead.
+#
+# Prefix strings are the *actual* Kestrel KG prefixes, verified live 2026-06-18 against hybrid-search rows
+# (e.g. RefMet is "RM", not "REFMET"). A wrong string is a silent no-op (the filter matches nothing).
+CATEGORY_PREFERRED_NAMESPACES: dict[str, set[str]] = {
+    "biolink:SmallMolecule": {"CHEBI", "HMDB", "RM"},
+    "biolink:Disease": {"MONDO"},
+}

--- a/src/biomapper2/core/annotation_engine.py
+++ b/src/biomapper2/core/annotation_engine.py
@@ -176,12 +176,13 @@ class AnnotationEngine:
         Expands each configured key (e.g. ``biolink:SmallMolecule``, ``biolink:Disease``) via
         ``get_descendants`` so subcategories inherit the policy, mirroring ``_human_applicable_categories``.
         Cached per instance: the Biolink hierarchy is static at runtime. If two configured keys' descendant
-        sets overlap, the later key wins for the shared category — keep the policy keys disjoint.
+        sets overlap (e.g. via a shared mixin), the shared category inherits the **union** of both policies'
+        prefixes rather than silently dropping one.
         """
         resolved: dict[str, set[str]] = {}
         for category, prefixes in CATEGORY_PREFERRED_NAMESPACES.items():
             for descendant in self.biolink_client.get_descendants(category):
-                resolved[descendant] = set(prefixes)
+                resolved.setdefault(descendant, set()).update(prefixes)
         return resolved
 
     def _select_annotators(self, category: str) -> list[str]:

--- a/src/biomapper2/core/annotation_engine.py
+++ b/src/biomapper2/core/annotation_engine.py
@@ -12,6 +12,7 @@ from typing import Any
 import pandas as pd
 
 from ..biolink_client import BiolinkClient
+from ..config import CATEGORY_PREFERRED_NAMESPACES
 from ..utils import AnnotationMode, AssignedIDsDict
 from .annotators.base import BaseAnnotator
 from .annotators.kestrel_hybrid import KestrelHybridSearchAnnotator
@@ -46,6 +47,7 @@ class AnnotationEngine:
         mode: AnnotationMode = "missing",
         annotators: list[str] | None = None,
         prefer_human: bool = True,
+        prefer_canonical: bool = True,
     ) -> pd.DataFrame | pd.Series:
         """
         Annotate entity with additional vocab IDs, obtained using various internal or external methods.
@@ -64,6 +66,10 @@ class AnnotationEngine:
             prefer_human: When True, prefer the human (HGNC-bearing) candidate for gene/protein
                 categories. This engine gates applicability by category (see below) and passes the
                 resolved, effective flag to the annotators.
+            prefer_canonical: When True, prefer the canonical-namespace candidate for non-gene
+                categories with a configured policy (e.g. CHEBI/HMDB/RM for metabolites, MONDO for
+                disease). The engine resolves the category's preferred-prefix set and passes it down;
+                gene/protein categories never receive a set (they use prefer_human).
 
         Returns:
             AssignedIDsDict (in a named Series) for single entity, and in a single-column
@@ -77,9 +83,18 @@ class AnnotationEngine:
         # Resolve the effective flag here so annotators receive an already-gated boolean.
         effective_prefer_human = prefer_human and self._is_human_applicable_category(category)
 
+        # Canonical-namespace preference applies to non-gene categories with a configured policy. The
+        # `not effective_prefer_human` clause enforces the mutually-exclusive partition (a category that
+        # is gene/protein-applicable never also receives a canonical set), even if the descendant sets
+        # overlap via mixins. None means "no canonical re-rank for this category".
+        effective_preferred_prefixes = (
+            self._category_preferred_prefixes.get(category) if prefer_canonical and not effective_prefer_human else None
+        )
+
         logging.info(
             f"Beginning annotation step.. (mode={mode}, annotators={annotators}, "
-            f"prefer_human={prefer_human}, effective_prefer_human={effective_prefer_human})"
+            f"prefer_human={prefer_human}, effective_prefer_human={effective_prefer_human}, "
+            f"prefer_canonical={prefer_canonical}, effective_preferred_prefixes={effective_preferred_prefixes})"
         )
 
         # Skip annotation if user requested it
@@ -119,6 +134,7 @@ class AnnotationEngine:
                     prefixes,
                     annotators_to_use,
                     effective_prefer_human,
+                    effective_preferred_prefixes,
                 )
             else:
                 return self._annotate_single(
@@ -130,6 +146,7 @@ class AnnotationEngine:
                     prefixes,
                     annotators_to_use,
                     effective_prefer_human,
+                    effective_preferred_prefixes,
                 )
         else:
             return self._get_empty_assigned_ids(item)
@@ -151,6 +168,21 @@ class AnnotationEngine:
     def _is_human_applicable_category(self, category: str) -> bool:
         """True if the category is a gene/protein (or Biolink descendant), where human-preference applies."""
         return category in self._human_applicable_categories
+
+    @cached_property
+    def _category_preferred_prefixes(self) -> dict[str, set[str]]:
+        """Map every category in the canonical-namespace policy (incl. Biolink descendants) to its set.
+
+        Expands each configured key (e.g. ``biolink:SmallMolecule``, ``biolink:Disease``) via
+        ``get_descendants`` so subcategories inherit the policy, mirroring ``_human_applicable_categories``.
+        Cached per instance: the Biolink hierarchy is static at runtime. If two configured keys' descendant
+        sets overlap, the later key wins for the shared category — keep the policy keys disjoint.
+        """
+        resolved: dict[str, set[str]] = {}
+        for category, prefixes in CATEGORY_PREFERRED_NAMESPACES.items():
+            for descendant in self.biolink_client.get_descendants(category):
+                resolved[descendant] = set(prefixes)
+        return resolved
 
     def _select_annotators(self, category: str) -> list[str]:
         """Select appropriate annotators based on entity type (returns their slugs)."""
@@ -177,6 +209,7 @@ class AnnotationEngine:
         prefixes: list[str],
         annotators: list,
         prefer_human: bool = True,
+        preferred_prefixes: set[str] | None = None,
     ) -> pd.DataFrame:
         """Annotate an entire DataFrame. Returns a single-column DataFrame containing AssignedIDsDicts."""
         if mode == "missing":
@@ -201,7 +234,12 @@ class AnnotationEngine:
             for annotator in annotators:
                 prepared_df = annotator.prepare(items_to_annotate, provided_id_fields)
                 annotations_col = annotator.get_annotations_bulk(
-                    prepared_df, name_field, category, prefixes, prefer_human=prefer_human
+                    prepared_df,
+                    name_field,
+                    category,
+                    prefixes,
+                    prefer_human=prefer_human,
+                    preferred_prefixes=preferred_prefixes,
                 )
                 annotated_rows = pd.Series(
                     [self._merge_nested_dicts(d1, d2) for d1, d2 in zip(annotated_rows, annotations_col)],
@@ -223,6 +261,7 @@ class AnnotationEngine:
         prefixes: list[str],
         annotators: list,
         prefer_human: bool = True,
+        preferred_prefixes: set[str] | None = None,
     ) -> pd.Series:
         """Annotate a single entity. Returns named series containing AssignedIDsDict."""
         # If user requested it, skip entities that have any provided IDs
@@ -237,7 +276,12 @@ class AnnotationEngine:
         for annotator in annotators:
             prepared_entity = annotator.prepare(item, provided_id_fields)
             entity_annotations = annotator.get_annotations(
-                prepared_entity, name_field, category, prefixes, prefer_human=prefer_human
+                prepared_entity,
+                name_field,
+                category,
+                prefixes,
+                prefer_human=prefer_human,
+                preferred_prefixes=preferred_prefixes,
             )
             assigned_ids: AssignedIDsDict = self._merge_nested_dicts(assigned_ids, entity_annotations)
 

--- a/src/biomapper2/core/annotators/base.py
+++ b/src/biomapper2/core/annotators/base.py
@@ -36,6 +36,7 @@ class BaseAnnotator(ABC):  # Inherit from ABC
         category: str,
         prefixes: list[str] | None = None,
         prefer_human: bool = True,
+        preferred_prefixes: set[str] | None = None,
         cache: dict | None = None,
     ) -> AssignedIDsDict:
         """
@@ -49,6 +50,9 @@ class BaseAnnotator(ABC):  # Inherit from ABC
             prefer_human: When True (and the category is gene/protein-applicable, as gated by the
                 engine), prefer the human (HGNC-bearing) candidate. Honored only by annotators where
                 a human marker applies; others accept and ignore it.
+            preferred_prefixes: When set (the engine resolves it for non-gene categories with a configured
+                canonical-namespace policy), prefer the candidate in that namespace set. Honored only by
+                annotators that re-rank (hybrid search); others accept and ignore it.
             cache: Optional pre-fetched results from bulk API call
 
         Returns:
@@ -64,6 +68,7 @@ class BaseAnnotator(ABC):  # Inherit from ABC
         category: str,
         prefixes: list[str] | None = None,
         prefer_human: bool = True,
+        preferred_prefixes: set[str] | None = None,
     ) -> pd.Series:  # Series of AssignedIdsDicts
         """
         Get annotations for multiple entities with bulk API call.
@@ -74,6 +79,7 @@ class BaseAnnotator(ABC):  # Inherit from ABC
             category: Biolink category (standardized entity type)
             prefixes: Allowed (standardized) curie prefixes to map to (e.g., 'CHEBI', 'MONDO')
             prefer_human: See get_annotations. Accepted by all annotators; honored where applicable.
+            preferred_prefixes: See get_annotations. Accepted by all annotators; honored where applicable.
 
         Returns:
             Column (Series) of annotation results (same index as input)

--- a/src/biomapper2/core/annotators/kestrel_hybrid.py
+++ b/src/biomapper2/core/annotators/kestrel_hybrid.py
@@ -34,24 +34,29 @@ class KestrelHybridSearchAnnotator(BaseAnnotator):
         category: str,
         prefixes: list[str] | None = None,
         prefer_human: bool = True,
+        preferred_prefixes: set[str] | None = None,
         cache: dict | None = None,
     ) -> AssignedIDsDict:
         """Implements BaseAnnotator.get_annotations.
 
-        When ``prefer_human`` is True the annotator retrieves multiple candidates and selects the
-        human (HGNC-bearing) one that matches the queried symbol, falling back to the top-scored
-        candidate on a miss (see ``_select_result``). When False it keeps the legacy top-1 behavior.
-        The engine passes the *applicability-gated* value (True only for gene/protein categories).
+        Two mutually-exclusive re-ranking policies, both gated by the engine (which sets at most one):
+        - ``prefer_human`` (gene/protein): select the human (HGNC-bearing) candidate matching the queried
+          symbol, with the curated drug-conflated fallback on a miss (see ``_select_result``).
+        - ``preferred_prefixes`` (other categories, e.g. metabolite/disease): prefer the canonical-namespace
+          candidate that matches the query, falling back to the top-scored canonical or — on an empty
+          canonical pool — the overall top-scored row (see ``_select_canonical``).
+        With neither active, the legacy top-1 behavior is kept.
         """
 
         # Extract the value to search
         search_term = entity.get(name_field)
         if text_is_not_empty(search_term):
-            # Use cache if available, otherwise make API call
+            # Use cache if available, otherwise make API call. The wider candidate window is needed for
+            # either re-ranking policy (the canonical/human node often ranks below the conflated top hit).
             if cache:
                 term_results = cache.get(search_term)
             else:
-                limit = HYBRID_SEARCH_LIMIT if prefer_human else 1
+                limit = HYBRID_SEARCH_LIMIT if (prefer_human or preferred_prefixes) else 1
                 results = self._kestrel_hybrid_search(search_term, category, prefixes, limit=limit)
                 term_results = results[search_term]
 
@@ -65,6 +70,14 @@ class KestrelHybridSearchAnnotator(BaseAnnotator):
                 resolved_curie = self._resolver.resolve(search_term)
                 if resolved_curie is not None:
                     chosen = {"id": resolved_curie, "score": _FALLBACK_SCORE, "resolved_via": "symbol_fallback"}
+            # Canonical-namespace preference (non-gene categories). The engine sets preferred_prefixes only
+            # when prefer_human is off for this category, so the two policies never compete.
+            elif preferred_prefixes:
+                canonical = self._select_canonical(term_results, preferred_prefixes, search_term)
+                chosen = canonical
+                if canonical is not None and str(canonical.get("id", "")).split(":", 1)[0] in preferred_prefixes:
+                    # Tag only a genuine canonical pick (not the empty-pool fallback to the top-scored row).
+                    chosen = {**canonical, "resolved_via": "canonical_preference"}
 
             if chosen is not None:
                 node_id = chosen["id"]
@@ -87,6 +100,7 @@ class KestrelHybridSearchAnnotator(BaseAnnotator):
         category: str,
         prefixes: list[str] | None = None,
         prefer_human: bool = True,
+        preferred_prefixes: set[str] | None = None,
     ) -> pd.Series:  # Series of AssignedIDsDicts
         """Implements BaseAnnotator.get_annotations_bulk"""
 
@@ -94,13 +108,14 @@ class KestrelHybridSearchAnnotator(BaseAnnotator):
         search_terms = [t for t in entities[name_field].tolist() if text_is_not_empty(t)]
 
         logging.info(f"Getting hybrid search results from Kestrel API for {len(entities)} entities")
-        # Only enlarge the candidate window when human-preference is active (keeps payloads small for
-        # metabolite/other bulk jobs where the re-ranking does not apply).
-        limit = HYBRID_SEARCH_LIMIT if prefer_human else 1
+        # Enlarge the candidate window when either re-ranking policy is active (keeps payloads small for
+        # bulk jobs where no re-ranking applies).
+        limit = HYBRID_SEARCH_LIMIT if (prefer_human or preferred_prefixes) else 1
         results = self._kestrel_hybrid_search(search_terms, category, prefixes, limit=limit)
 
         # Annotate each entity using the results from the bulk request. The internal re-dispatch MUST
-        # forward prefer_human, otherwise the bulk path would silently use the get_annotations default.
+        # forward BOTH prefer_human and preferred_prefixes, otherwise the bulk path would silently use the
+        # get_annotations defaults (a silent no-op for the canonical re-rank on dataset jobs).
         assigned_ids_col = entities.apply(
             self.get_annotations,
             axis=1,
@@ -109,6 +124,7 @@ class KestrelHybridSearchAnnotator(BaseAnnotator):
             category=category,
             prefixes=prefixes,
             prefer_human=prefer_human,
+            preferred_prefixes=preferred_prefixes,
         )
 
         return cast(pd.Series, assigned_ids_col)
@@ -149,6 +165,34 @@ class KestrelHybridSearchAnnotator(BaseAnnotator):
             return max(exact, key=lambda r: r.get("score", 0)), True
         # HGNC rows exist but none symbol-match the query (e.g. a paralog) — not a genuine match.
         return max(human, key=lambda r: r.get("score", 0)), False
+
+    @staticmethod
+    def _select_canonical(
+        term_results: list[dict] | None, preferred_prefixes: set[str], search_term: str
+    ) -> dict | None:
+        """Select the canonical-namespace candidate for a non-gene category, else the honest top-1.
+
+        Validated against live Kestrel data (2026-06-18): within a category the canonical node (CHEBI/HMDB/
+        RM for metabolites, MONDO for disease) routinely scores well *below* a conflated non-canonical node
+        (UMLS/ICD/KEGG/PANTHER), so score is not a gate — the namespace filter plus an identity match is the
+        discriminator. There is deliberately **no score-margin guard**.
+
+        1. Filter to rows whose ``id`` namespace is in ``preferred_prefixes`` (the chosen row's id is the
+           assigned CURIE, so this guarantees a canonical result — not merely a cross-referenced one).
+        2. Empty pool → honest fallback to the overall top-scored row (never fabricate a canonical CURIE).
+        3. Among the pool, prefer the rows whose ``name``/synonym matches the query (reuses ``_symbol_matches``
+           directly), then take the highest-scoring of that sub-pool; if none match, the top-scored canonical
+           row. This picks the right concept among same-namespace homonyms (e.g. CHEBI isomers) and the right
+           specific node when the query does not exact-match any name (e.g. the top-scored MONDO for a disease).
+        """
+        if not term_results:
+            return None
+        pool = [r for r in term_results if str(r.get("id", "")).split(":", 1)[0] in preferred_prefixes]
+        if not pool:
+            return term_results[0]
+        exact = [r for r in pool if KestrelHybridSearchAnnotator._symbol_matches(r, search_term)]
+        candidates = exact if exact else pool
+        return max(candidates, key=lambda r: r.get("score", 0))
 
     @staticmethod
     def _symbol_matches(row: dict, search_term: str) -> bool:

--- a/src/biomapper2/core/annotators/kestrel_hybrid.py
+++ b/src/biomapper2/core/annotators/kestrel_hybrid.py
@@ -70,14 +70,15 @@ class KestrelHybridSearchAnnotator(BaseAnnotator):
                 resolved_curie = self._resolver.resolve(search_term)
                 if resolved_curie is not None:
                     chosen = {"id": resolved_curie, "score": _FALLBACK_SCORE, "resolved_via": "symbol_fallback"}
-            # Canonical-namespace preference (non-gene categories). The engine sets preferred_prefixes only
-            # when prefer_human is off for this category, so the two policies never compete.
+            # Canonical-namespace preference (non-gene categories). This is an `elif`: the engine sets
+            # preferred_prefixes only when prefer_human is off for this category, so the two policies are
+            # mutually exclusive — and even if a direct caller set both, the gene branch above wins.
             elif preferred_prefixes:
-                canonical = self._select_canonical(term_results, preferred_prefixes, search_term)
-                chosen = canonical
-                if canonical is not None and str(canonical.get("id", "")).split(":", 1)[0] in preferred_prefixes:
-                    # Tag only a genuine canonical pick (not the empty-pool fallback to the top-scored row).
-                    chosen = {**canonical, "resolved_via": "canonical_preference"}
+                chosen, is_canonical = self._select_canonical(term_results, preferred_prefixes, search_term)
+                if chosen is not None and is_canonical:
+                    # Tag only a genuine canonical pick (the selector reports it — not the empty-pool
+                    # fallback to the top-scored non-canonical row).
+                    chosen = {**chosen, "resolved_via": "canonical_preference"}
 
             if chosen is not None:
                 node_id = chosen["id"]
@@ -169,30 +170,38 @@ class KestrelHybridSearchAnnotator(BaseAnnotator):
     @staticmethod
     def _select_canonical(
         term_results: list[dict] | None, preferred_prefixes: set[str], search_term: str
-    ) -> dict | None:
+    ) -> tuple[dict | None, bool]:
         """Select the canonical-namespace candidate for a non-gene category, else the honest top-1.
+
+        Returns ``(chosen_row, is_canonical)`` where ``is_canonical`` is True only when ``chosen_row`` came
+        from the preferred-namespace pool — so the caller can tag provenance without re-deriving the
+        namespace it already filtered on. It is False for an empty result and for the empty-pool fallback.
 
         Validated against live Kestrel data (2026-06-18): within a category the canonical node (CHEBI/HMDB/
         RM for metabolites, MONDO for disease) routinely scores well *below* a conflated non-canonical node
         (UMLS/ICD/KEGG/PANTHER), so score is not a gate — the namespace filter plus an identity match is the
         discriminator. There is deliberately **no score-margin guard**.
 
-        1. Filter to rows whose ``id`` namespace is in ``preferred_prefixes`` (the chosen row's id is the
-           assigned CURIE, so this guarantees a canonical result — not merely a cross-referenced one).
-        2. Empty pool → honest fallback to the overall top-scored row (never fabricate a canonical CURIE).
+        1. Filter to rows whose ``id`` namespace is in ``preferred_prefixes``. Filtering on the ``id``
+           (the assigned CURIE) — not the broader ``prefixes`` xref list ``_select_result`` uses — guarantees
+           the *assigned* result is canonical, not merely cross-referenced. The comparison is case-insensitive
+           so a differently-cased KG prefix can't silently empty the pool.
+        2. Empty pool → honest fallback to the overall top-scored row, ``is_canonical=False`` (never
+           fabricate a canonical CURIE).
         3. Among the pool, prefer the rows whose ``name``/synonym matches the query (reuses ``_symbol_matches``
            directly), then take the highest-scoring of that sub-pool; if none match, the top-scored canonical
            row. This picks the right concept among same-namespace homonyms (e.g. CHEBI isomers) and the right
            specific node when the query does not exact-match any name (e.g. the top-scored MONDO for a disease).
         """
         if not term_results:
-            return None
-        pool = [r for r in term_results if str(r.get("id", "")).split(":", 1)[0] in preferred_prefixes]
+            return None, False
+        preferred_cf = {p.casefold() for p in preferred_prefixes}
+        pool = [r for r in term_results if str(r.get("id", "")).split(":", 1)[0].casefold() in preferred_cf]
         if not pool:
-            return term_results[0]
+            return term_results[0], False
         exact = [r for r in pool if KestrelHybridSearchAnnotator._symbol_matches(r, search_term)]
         candidates = exact if exact else pool
-        return max(candidates, key=lambda r: r.get("score", 0))
+        return max(candidates, key=lambda r: r.get("score", 0)), True
 
     @staticmethod
     def _symbol_matches(row: dict, search_term: str) -> bool:

--- a/src/biomapper2/core/annotators/kestrel_hybrid.py
+++ b/src/biomapper2/core/annotators/kestrel_hybrid.py
@@ -70,9 +70,11 @@ class KestrelHybridSearchAnnotator(BaseAnnotator):
                 resolved_curie = self._resolver.resolve(search_term)
                 if resolved_curie is not None:
                     chosen = {"id": resolved_curie, "score": _FALLBACK_SCORE, "resolved_via": "symbol_fallback"}
-            # Canonical-namespace preference (non-gene categories). This is an `elif`: the engine sets
-            # preferred_prefixes only when prefer_human is off for this category, so the two policies are
-            # mutually exclusive — and even if a direct caller set both, the gene branch above wins.
+            # Canonical-namespace preference (non-gene categories). Mutual exclusivity with the gene path
+            # is enforced by the *engine*, which sets preferred_prefixes only when prefer_human is off for
+            # this category — not by this branch structure. (As an `elif` on the gene `if`, a hypothetical
+            # caller passing both an effective prefer_human and preferred_prefixes would, on a genuine gene
+            # match, fall through to here and override it; that combination never occurs via the engine.)
             elif preferred_prefixes:
                 chosen, is_canonical = self._select_canonical(term_results, preferred_prefixes, search_term)
                 if chosen is not None and is_canonical:

--- a/src/biomapper2/core/annotators/kestrel_text.py
+++ b/src/biomapper2/core/annotators/kestrel_text.py
@@ -19,6 +19,7 @@ class KestrelTextSearchAnnotator(BaseAnnotator):
         category: str,
         prefixes: list[str] | None = None,
         prefer_human: bool = True,  # accepted for interface parity; not applicable to text search
+        preferred_prefixes: set[str] | None = None,  # accepted for interface parity; not applicable
         cache: dict | None = None,
     ) -> AssignedIDsDict:
         """Implements BaseAnnotator.get_annotations"""
@@ -53,6 +54,7 @@ class KestrelTextSearchAnnotator(BaseAnnotator):
         category: str,
         prefixes: list[str] | None = None,
         prefer_human: bool = True,  # accepted for interface parity; not applicable to text search
+        preferred_prefixes: set[str] | None = None,  # accepted for interface parity; not applicable
     ) -> pd.Series:  # Series of AssignedIDsDicts
         """Implements BaseAnnotator.get_annotations_bulk"""
 

--- a/src/biomapper2/core/annotators/kestrel_vector.py
+++ b/src/biomapper2/core/annotators/kestrel_vector.py
@@ -19,6 +19,7 @@ class KestrelVectorSearchAnnotator(BaseAnnotator):
         category: str,
         prefixes: list[str] | None = None,
         prefer_human: bool = True,  # accepted for interface parity; not applicable to vector search
+        preferred_prefixes: set[str] | None = None,  # accepted for interface parity; not applicable
         cache: dict | None = None,
     ) -> AssignedIDsDict:
         """Implements BaseAnnotator.get_annotations"""
@@ -53,6 +54,7 @@ class KestrelVectorSearchAnnotator(BaseAnnotator):
         category: str,
         prefixes: list[str] | None = None,
         prefer_human: bool = True,  # accepted for interface parity; not applicable to vector search
+        preferred_prefixes: set[str] | None = None,  # accepted for interface parity; not applicable
     ) -> pd.Series:  # Series of AssignedIDsDicts
         """Implements BaseAnnotator.get_annotations_bulk"""
 

--- a/src/biomapper2/core/annotators/metabolomics_workbench.py
+++ b/src/biomapper2/core/annotators/metabolomics_workbench.py
@@ -46,6 +46,7 @@ class MetabolomicsWorkbenchAnnotator(BaseAnnotator):
         category: str,
         prefixes: list[str] | None = None,
         prefer_human: bool = True,  # accepted for interface parity; metabolites have no HGNC analogue
+        preferred_prefixes: set[str] | None = None,  # parity; MW returns raw IDs, no namespace re-rank
         cache: dict | None = None,
     ) -> AssignedIDsDict:
         """Implements BaseAnnotator.get_annotations"""
@@ -85,6 +86,7 @@ class MetabolomicsWorkbenchAnnotator(BaseAnnotator):
         category: str,
         prefixes: list[str] | None = None,
         prefer_human: bool = True,  # accepted for interface parity; metabolites have no HGNC analogue
+        preferred_prefixes: set[str] | None = None,  # parity; MW returns raw IDs, no namespace re-rank
     ) -> pd.Series:
         """Implements BaseAnnotator.get_annotations_bulk"""
 

--- a/src/biomapper2/core/gene_symbol_resolver.py
+++ b/src/biomapper2/core/gene_symbol_resolver.py
@@ -64,11 +64,14 @@ class GeneSymbolResolver:
                 json={"slim": False, "truncate_long_fields": False},
             )
         except Exception as exc:
-            # Network errors are already logged + re-raised upstream by the request layer; this guard
-            # exists for non-network failures (e.g. a malformed response body). Log so a curated gene
-            # silently ceasing to resolve leaves a diagnostic trace instead of vanishing.
+            # Catch-all by design: ANY /get-nodes failure — a Kestrel outage (already logged by the
+            # request layer) or a non-network failure like a malformed/changed response body — is
+            # suppressed here to an honest no-op (the entity falls back to whatever the search step
+            # chose, typically an ortholog). Nothing propagates to the caller, so this warning is the
+            # ONLY signal that a curated gene stopped resolving — there is no exception, test failure,
+            # or alert. (A Kestrel outage therefore silently disables the bridge for all six genes.)
             logging.warning(f"gene-symbol fallback: get-nodes failed for {curie} ({symbol!r}): {exc}")
-            return None  # honest fallback on any Kestrel error
+            return None
 
         node = nodes.get(curie) if isinstance(nodes, dict) else None
         if not isinstance(node, dict):

--- a/src/biomapper2/mapper.py
+++ b/src/biomapper2/mapper.py
@@ -56,6 +56,7 @@ class Mapper:
         annotation_mode: AnnotationMode = "missing",
         annotators: list[str] | None = None,
         prefer_human: bool = True,
+        prefer_canonical: bool = True,
     ) -> pd.Series | dict[str, Any]:
         """
         Map a single entity to knowledge graph nodes.
@@ -96,6 +97,7 @@ class Mapper:
             mode=annotation_mode,
             annotators=annotators,
             prefer_human=prefer_human,
+            prefer_canonical=prefer_canonical,
         )
         assert isinstance(annotation_result, pd.Series)
         entity = entity.update_from(annotation_result)
@@ -142,6 +144,7 @@ class Mapper:
         annotation_mode: AnnotationMode = "missing",
         annotators: list[str] | None = None,
         prefer_human: bool = True,
+        prefer_canonical: bool = True,
     ) -> tuple[str, dict[str, Any]]:
         """
         Map all entities in a dataset to knowledge graph nodes.
@@ -222,6 +225,7 @@ class Mapper:
             mode=annotation_mode,
             annotators=annotators,
             prefer_human=prefer_human,
+            prefer_canonical=prefer_canonical,
         )
         df = df.join(annotation_df)
         logging.info(f"After step 1 (annotation), df is: \n{df}")

--- a/tests/test_annotation_engine_canonical.py
+++ b/tests/test_annotation_engine_canonical.py
@@ -1,0 +1,98 @@
+"""Tests for the engine's canonical-namespace policy resolution (prefer_canonical gating).
+
+Uses a MagicMock BiolinkClient so no bmt/network init is needed: get_descendants returns a controllable
+descendant set. A spy annotator records the preferred_prefixes the engine resolves and passes down.
+"""
+
+from unittest.mock import MagicMock
+
+import pandas as pd
+
+from biomapper2.core.annotation_engine import AnnotationEngine
+from biomapper2.core.annotators.base import BaseAnnotator
+
+
+class _SpyAnnotator(BaseAnnotator):
+    slug = "spy"
+
+    def __init__(self):
+        self.received = []
+
+    def get_annotations(
+        self, entity, name_field, category, prefixes=None, prefer_human=True, preferred_prefixes=None, cache=None
+    ):
+        self.received.append(preferred_prefixes)
+        return {self.slug: {}}
+
+    def get_annotations_bulk(
+        self, entities, name_field, category, prefixes=None, prefer_human=True, preferred_prefixes=None
+    ):
+        self.received.append(preferred_prefixes)
+        return pd.Series([{self.slug: {}} for _ in range(len(entities))], index=entities.index)
+
+
+def _engine(descendants_side_effect=None):
+    bc = MagicMock()
+    bc.get_descendants.side_effect = descendants_side_effect or (lambda c: {c})
+    engine = AnnotationEngine(biolink_client=bc)
+    spy = _SpyAnnotator()
+    engine.annotator_registry["spy"] = spy
+    return engine, spy
+
+
+def _resolve(engine, spy, category, prefer_canonical=True):
+    engine.annotate(
+        item={"name": "x"},
+        name_field="name",
+        provided_id_fields=[],
+        category=category,
+        prefixes=[],
+        mode="all",
+        annotators=["spy"],
+        prefer_canonical=prefer_canonical,
+    )
+    return spy.received[-1]
+
+
+class TestCanonicalPolicyResolution:
+    def test_preferred_prefixes_map_expands_via_descendants(self):
+        engine, _ = _engine()
+        assert engine._category_preferred_prefixes["biolink:SmallMolecule"] == {"CHEBI", "HMDB", "RM"}
+        assert engine._category_preferred_prefixes["biolink:Disease"] == {"MONDO"}
+
+    def test_metabolite_receives_canonical_set(self):
+        engine, spy = _engine()
+        assert _resolve(engine, spy, "biolink:SmallMolecule") == {"CHEBI", "HMDB", "RM"}
+
+    def test_disease_descendant_inherits_policy(self):
+        # A disease subcategory is a descendant of biolink:Disease -> inherits {MONDO}.
+        engine, spy = _engine(
+            descendants_side_effect=lambda c: {"biolink:Disease", "biolink:Mass"} if c == "biolink:Disease" else {c}
+        )
+        assert _resolve(engine, spy, "biolink:Mass") == {"MONDO"}
+
+    def test_gene_receives_none(self):
+        # biolink:Gene is human-applicable -> prefer_human wins, no canonical set.
+        engine, spy = _engine(descendants_side_effect=lambda c: {"biolink:Gene"} if c == "biolink:Gene" else {c})
+        assert _resolve(engine, spy, "biolink:Gene") is None
+
+    def test_prefer_canonical_false_yields_none(self):
+        engine, spy = _engine()
+        assert _resolve(engine, spy, "biolink:SmallMolecule", prefer_canonical=False) is None
+
+    def test_unconfigured_category_yields_none(self):
+        engine, spy = _engine()
+        assert _resolve(engine, spy, "biolink:OrganismTaxon") is None
+
+    def test_precedence_human_wins_when_category_in_both_sets(self):
+        # A category that is BOTH a gene descendant AND in a preferred-namespace key resolves to None
+        # (prefer_human precedence) — locks the `not effective_prefer_human` ordering.
+        def descendants(c):
+            if c == "biolink:Gene":
+                return {"biolink:Gene", "biolink:Overlap"}
+            if c == "biolink:SmallMolecule":
+                return {"biolink:SmallMolecule", "biolink:Overlap"}
+            return {c}
+
+        engine, spy = _engine(descendants_side_effect=descendants)
+        assert _resolve(engine, spy, "biolink:Overlap") is None

--- a/tests/test_canonical_namespace_gold_set.py
+++ b/tests/test_canonical_namespace_gold_set.py
@@ -1,0 +1,102 @@
+"""Live merge-gate: metabolite/disease entities must resolve to the canonical-namespace node.
+
+Marked `integration` (hits the live Kestrel API). Runs the full pipeline via Mapper.map_entity_to_kg with
+the default-on prefer_canonical behavior, asserts each gold entity resolves to a canonical-namespace node
+(CHEBI/HMDB/RM for metabolites, MONDO for disease) — not a same-text non-canonical node (UMLS/ICD/KEGG) —
+and persists a timestamped report (per the experiment-artifact SOP). The report includes a
+canonical-flip efficacy column so a silent no-op (canonical present but not selected) is observable.
+
+Expected nodes are taken from a live probe 2026-06-18; the gate asserts the namespace prefix (robust to
+node-id churn) and records the exact chosen CURIE. A gene case is included as a regression guard: the
+canonical re-rank must not touch gene/protein resolution (that path uses prefer_human).
+"""
+
+import json
+from datetime import datetime, timezone
+
+import pytest
+
+from biomapper2.config import PROJECT_ROOT
+
+# Each gold entity must resolve to a node whose namespace is in the expected canonical set.
+METABOLITE_GOLD = {
+    "kynurenine": {"CHEBI", "HMDB", "RM"},
+    "serotonin": {"CHEBI", "HMDB", "RM"},
+}
+DISEASE_GOLD = {
+    "Parkinson disease": {"MONDO"},
+    "chronic myeloid leukemia": {"MONDO"},
+}
+# Gene regression guard: must still resolve to the human NCBIGene (prefer_human path, unaffected).
+GENE_REGRESSION = {"TNFRSF1A": "NCBIGene"}
+
+
+def _prefix(curie):
+    return str(curie).split(":", 1)[0] if curie else None
+
+
+def _map(shared_mapper, name, entity_type):
+    return shared_mapper.map_entity_to_kg(
+        item={"name": name}, name_field="name", provided_id_fields=[], entity_type=entity_type
+    )
+
+
+@pytest.fixture(scope="module")
+def gold_set_run(shared_mapper):
+    """Run the gold set live once, persist a timestamped report, return per-entity results."""
+    rows = []
+    for name, expected in {**METABOLITE_GOLD, **DISEASE_GOLD}.items():
+        etype = "metabolite" if name in METABOLITE_GOLD else "disease"
+        result = _map(shared_mapper, name, etype)
+        chosen = result.get("chosen_kg_id")
+        rows.append(
+            {
+                "name": name,
+                "entity_type": etype,
+                "expected_prefixes": sorted(expected),
+                "chosen_kg_id": chosen,
+                "chosen_prefix": _prefix(chosen),
+                "is_canonical": _prefix(chosen) in expected,
+            }
+        )
+
+    n = len(rows)
+    n_canonical = sum(r["is_canonical"] for r in rows)
+    report = {
+        "generated_utc": datetime.now(timezone.utc).isoformat(),
+        "prefer_canonical": True,
+        "n_total": n,
+        "n_resolved_canonical": n_canonical,
+        # Efficacy: fraction resolved to a canonical node. A low value on entities known to have a
+        # canonical node signals the selector is silently no-op'ing (the failure mode the probe guards).
+        "canonical_fraction": round(n_canonical / n, 3) if n else 0.0,
+        "rows": rows,
+    }
+
+    out_dir = PROJECT_ROOT / "results"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    out_path = out_dir / f"canonical_namespace_gold_set_{stamp}.json"
+    out_path.write_text(json.dumps(report, indent=2))
+    print(f"\n[canonical-gold-set] saved {out_path} (canonical_fraction={report['canonical_fraction']})")
+    return report
+
+
+@pytest.mark.integration
+class TestCanonicalNamespaceGoldSet:
+    @pytest.mark.parametrize("name", sorted({**METABOLITE_GOLD, **DISEASE_GOLD}))
+    def test_resolves_to_canonical_namespace(self, gold_set_run, name):
+        """Each gold entity resolves to a node in the expected canonical namespace set."""
+        row = next(r for r in gold_set_run["rows"] if r["name"] == name)
+        expected = {**METABOLITE_GOLD, **DISEASE_GOLD}[name]
+        assert row["chosen_prefix"] in expected, f"{name} -> {row['chosen_kg_id']} (expected one of {expected})"
+
+    def test_canonical_fraction_reported(self, gold_set_run):
+        """Every gold entity flips to canonical (efficacy metric persisted; guards the silent no-op)."""
+        assert 0.0 <= gold_set_run["canonical_fraction"] <= 1.0
+        assert gold_set_run["n_resolved_canonical"] == gold_set_run["n_total"]
+
+    def test_gene_regression_unaffected(self, shared_mapper):
+        """The canonical re-rank must not touch gene/protein resolution (prefer_human path)."""
+        result = _map(shared_mapper, "TNFRSF1A", "gene")
+        assert _prefix(result.get("chosen_kg_id")) == GENE_REGRESSION["TNFRSF1A"]

--- a/tests/test_human_gene_gold_set.py
+++ b/tests/test_human_gene_gold_set.py
@@ -1,14 +1,21 @@
-"""Live merge-gate validation: human genes/proteins must resolve to the human node, not an ortholog.
+"""Live merge-gate validation: human genes/proteins must resolve into the correct human-gene clique.
 
 Marked `integration` (hits the live Kestrel API). Runs the full pipeline via Mapper.map_entity_to_kg
-with the default-on prefer_human behavior, asserts each gold entity resolves to the expected human
-NCBIGene carrying an HGNC marker, and persists a timestamped report (per the experiment-artifact SOP).
+with the default-on prefer_human behavior, asserts each gold entity resolves to a KG node whose
+equivalent-id clique contains the expected human NCBIGene **and** an HGNC marker, and persists a
+timestamped report (per the experiment-artifact SOP).
 
 Two classes of positive case:
 - Search-recoverable (TNFRSF1A/TNFRSF1B/LDLR): the human node is in the candidate set and `prefer_human`
-  re-ranking selects it. The TNFRSF1A/TNFRSF1B pair exercises the paralog guard.
+  re-ranking selects it; `chosen_kg_id` is the exact NCBIGene. The TNFRSF1A/TNFRSF1B pair exercises the
+  paralog guard.
 - Drug-conflated (GH1/CALCA/POMC/CRH/CTLA4/GBA1): the human node is unreachable by any Kestrel search
-  (conflated into a drug node), so it resolves only via the curated gene-symbol fallback bridge.
+  (conflated into a drug node), so it resolves only via the curated gene-symbol fallback bridge. The
+  bridge assigns the right NCBIGene, but the KG's canonicalize step then collapses it into its
+  over-merged clique whose *representative* is a drug/chemical node (CALCA -> CHEBI:3306 "calcitonin",
+  GH1 -> UNII:NQX9KB6PCL "SOMATROPIN"). So `chosen_kg_id == NCBIGene:X` is unsatisfiable for these — the
+  achievable, biologically-correct assertion is that the chosen node's clique *contains* the expected
+  NCBIGene (verified live 2026-06-18: those clique nodes carry both the NCBIGene and an HGNC equivalent).
 """
 
 import json
@@ -41,6 +48,18 @@ HYBRID_SLUG = "kestrel-hybrid-search"
 def _has_hgnc(result: dict) -> bool:
     """True if the resolved node carries an HGNC marker in its equivalent ids."""
     return "HGNC" in json.dumps(result.get("kg_equivalent_ids", {}))
+
+
+def _clique_contains(result: dict, expected_curie: str) -> bool:
+    """True if the chosen node's equivalent-id clique contains ``expected_curie``.
+
+    ``kg_equivalent_ids`` is ``{prefix: [local_id, ...]}`` for the chosen node (see Linker.get_equivalent_ids).
+    For a search-recoverable gene the chosen node *is* the expected NCBIGene (and lists itself); for a
+    drug-conflated gene the chosen node is the clique's drug/chemical representative, which still carries
+    the expected NCBIGene among its equivalents. Either way this membership check holds.
+    """
+    prefix, local_id = expected_curie.split(":", 1)
+    return local_id in (result.get("kg_equivalent_ids", {}).get(prefix, []) or [])
 
 
 def _resolved_via(result: dict) -> str | None:
@@ -80,7 +99,10 @@ def gold_set_run(shared_mapper):
                 "name": name,
                 "expected_human": expected,
                 "chosen_kg_id": chosen,
-                "is_expected_human": chosen == expected,
+                "is_exact": chosen == expected,
+                # The achievable assertion: resolution landed in the expected gene's clique (exact for
+                # search-recoverable genes; the drug-canonical representative for conflated ones).
+                "resolved_to_clique": (chosen == expected) or _clique_contains(result, expected),
                 "has_hgnc": _has_hgnc(result),
                 "resolved_via": _resolved_via(result),
                 "is_positive": name in POSITIVE_GOLD,
@@ -96,7 +118,7 @@ def gold_set_run(shared_mapper):
         "prefer_human": True,
         "n_total": len(rows),
         "n_positive": len(positives),
-        "n_positive_resolved": sum(r["is_expected_human"] for r in positives),
+        "n_resolved_to_clique": sum(r["resolved_to_clique"] for r in positives),
         "n_resolved_via_bridge": len(via_bridge),
         "fallback_fraction": round(len(via_bridge) / len(rows), 3),
         "rows": rows,
@@ -115,29 +137,33 @@ def gold_set_run(shared_mapper):
 @pytest.mark.integration
 class TestHumanGeneGoldSet:
     @pytest.mark.parametrize("name", sorted(POSITIVE_GOLD))
-    def test_positive_resolves_to_human_node(self, gold_set_run, name):
-        """Each positive gold entity resolves to the expected human NCBIGene AND carries an HGNC marker."""
+    def test_positive_resolves_into_human_clique(self, gold_set_run, name):
+        """Each positive gold entity resolves into the expected gene's clique, carrying an HGNC marker."""
         row = next(r for r in gold_set_run["rows"] if r["name"] == name)
-        assert row["chosen_kg_id"] == POSITIVE_GOLD[name], f"{name} -> {row['chosen_kg_id']} (expected human)"
+        assert row[
+            "resolved_to_clique"
+        ], f"{name} -> {row['chosen_kg_id']} whose clique does not contain {POSITIVE_GOLD[name]}"
         assert row["has_hgnc"], f"{name} resolved node lacks an HGNC marker"
 
     def test_drug_conflated_resolves_via_fallback(self, gold_set_run):
         """The drug-conflated genes (unreachable by any Kestrel search) resolve via the curated bridge.
 
-        Asserts both the outcome (correct human node) AND the mechanism (the provenance marker proves
-        the bridge fired) — so a future regression where search starts surfacing these by coincidence
-        cannot pass this test silently.
+        Asserts the mechanism (the provenance marker proves the bridge fired) and that resolution lands in
+        the expected gene's clique. Note the KG canonicalizes these into a drug/chemical representative
+        (so `chosen_kg_id` is e.g. CHEBI/UNII, not the NCBIGene) — clique membership is what's achievable.
         """
         for name in ("GH1", "CALCA", "POMC", "CRH", "CTLA4", "GBA1"):
             row = next(r for r in gold_set_run["rows"] if r["name"] == name)
-            assert row["chosen_kg_id"] == POSITIVE_GOLD[name], f"{name} -> {row['chosen_kg_id']} (expected human)"
+            assert row[
+                "resolved_to_clique"
+            ], f"{name} -> {row['chosen_kg_id']} whose clique does not contain {POSITIVE_GOLD[name]}"
             assert row["has_hgnc"], f"{name} resolved node lacks an HGNC marker"
             assert row["resolved_via"] == "symbol_fallback", f"{name} did not resolve via the curated bridge"
 
-    def test_fallback_fraction_reported(self, gold_set_run):
-        """The run quantifies and persists how often the bridge fired (R8 observability)."""
+    def test_resolution_and_bridge_usage_reported(self, gold_set_run):
+        """The run quantifies clique resolution and how often the bridge fired (R8 observability)."""
         assert 0.0 <= gold_set_run["fallback_fraction"] <= 1.0
-        # With the curated fallback bridge in place, every gold gene should resolve to its human node.
-        assert gold_set_run["n_positive_resolved"] == gold_set_run["n_positive"]
+        # Every gold gene should resolve into its expected human-gene clique.
+        assert gold_set_run["n_resolved_to_clique"] == gold_set_run["n_positive"]
         # The fraction is read from real provenance: exactly the six drug-conflated genes use the bridge.
         assert gold_set_run["n_resolved_via_bridge"] == 6

--- a/tests/test_human_gene_gold_set.py
+++ b/tests/test_human_gene_gold_set.py
@@ -146,11 +146,13 @@ class TestHumanGeneGoldSet:
         assert row["has_hgnc"], f"{name} resolved node lacks an HGNC marker"
 
     def test_drug_conflated_resolves_via_fallback(self, gold_set_run):
-        """The drug-conflated genes (unreachable by any Kestrel search) resolve via the curated bridge.
+        """The drug-conflated genes resolve into the expected clique; while still conflated, via the bridge.
 
-        Asserts the mechanism (the provenance marker proves the bridge fired) and that resolution lands in
-        the expected gene's clique. Note the KG canonicalizes these into a drug/chemical representative
-        (so `chosen_kg_id` is e.g. CHEBI/UNII, not the NCBIGene) — clique membership is what's achievable.
+        Hard assertion: each lands in the expected gene's clique (the KG canonicalizes these into a
+        drug/chemical representative, so `chosen_kg_id` is e.g. CHEBI/UNII, not the NCBIGene). The bridge
+        marker is required **only while a gene is still conflated** (not resolving to its exact NCBIGene):
+        if upstream Babel/Kestrel de-conflates one — the documented desired fix — it becomes
+        search-recoverable (`is_exact`) and no longer needs the bridge, which must NOT read as a regression.
         """
         for name in ("GH1", "CALCA", "POMC", "CRH", "CTLA4", "GBA1"):
             row = next(r for r in gold_set_run["rows"] if r["name"] == name)
@@ -158,12 +160,15 @@ class TestHumanGeneGoldSet:
                 "resolved_to_clique"
             ], f"{name} -> {row['chosen_kg_id']} whose clique does not contain {POSITIVE_GOLD[name]}"
             assert row["has_hgnc"], f"{name} resolved node lacks an HGNC marker"
-            assert row["resolved_via"] == "symbol_fallback", f"{name} did not resolve via the curated bridge"
+            if not row["is_exact"]:
+                # Still conflated -> the only way it reached the right clique is the curated bridge.
+                assert row["resolved_via"] == "symbol_fallback", f"{name} did not resolve via the curated bridge"
 
     def test_resolution_and_bridge_usage_reported(self, gold_set_run):
         """The run quantifies clique resolution and how often the bridge fired (R8 observability)."""
         assert 0.0 <= gold_set_run["fallback_fraction"] <= 1.0
-        # Every gold gene should resolve into its expected human-gene clique.
+        # Hard gate: every gold gene resolves into its expected human-gene clique.
         assert gold_set_run["n_resolved_to_clique"] == gold_set_run["n_positive"]
-        # The fraction is read from real provenance: exactly the six drug-conflated genes use the bridge.
-        assert gold_set_run["n_resolved_via_bridge"] == 6
+        # Bridge usage is bounded by the curated set, not hard-pinned to 6: upstream de-conflation (the
+        # desired fix) reduces it as genes become search-recoverable — that is success, not a regression.
+        assert 0 <= gold_set_run["n_resolved_via_bridge"] <= 6

--- a/tests/test_kestrel_hybrid_canonical.py
+++ b/tests/test_kestrel_hybrid_canonical.py
@@ -1,0 +1,100 @@
+"""Tests for the canonical-namespace selection in the hybrid annotator (prefer_canonical path).
+
+The `_select_canonical` cases mirror live Kestrel `hybrid-search` data captured 2026-06-18: the canonical
+node (CHEBI/HMDB/RM for metabolites, MONDO for disease) routinely scores well *below* a conflated
+non-canonical node, so there is deliberately no score-margin guard — the namespace filter plus an identity
+match is the discriminator. The wiring cases run through the annotator's cache path so no network call is made.
+"""
+
+from unittest.mock import patch
+
+from biomapper2.core.annotators.kestrel_hybrid import KestrelHybridSearchAnnotator
+
+MET = {"CHEBI", "HMDB", "RM"}
+
+
+def _row(node_id, score, name, synonyms=None):
+    return {"id": node_id, "score": score, "name": name, "synonyms": synonyms or []}
+
+
+class TestSelectCanonical:
+    def test_identity_match_below_noncanonical_top(self):
+        """kynurenine: CHEBI node name-matches the query though it scores far below the UMLS top hit."""
+        rows = [
+            _row("UMLS:C0022818", 4.89, "Kynurenine"),
+            _row("CHEBI:28683", 2.50, "kynurenine"),
+            _row("CHEBI:16946", 2.49, "L-kynurenine"),
+        ]
+        chosen = KestrelHybridSearchAnnotator._select_canonical(rows, MET, "kynurenine")
+        assert chosen is not None and chosen["id"] == "CHEBI:28683"
+
+    def test_name_mismatch_takes_top_scored_canonical(self):
+        """CML: no MONDO name-matches the colloquial query -> the top-scored MONDO is chosen."""
+        rows = [
+            _row("KEGG:05220", 4.86, "Chronic myeloid leukemia"),
+            _row("MONDO:0011996", 2.50, "chronic myelogenous leukemia, BCR-ABL1 positive"),
+            _row("MONDO:0004643", 1.50, "myeloid leukemia"),
+        ]
+        chosen = KestrelHybridSearchAnnotator._select_canonical(rows, {"MONDO"}, "chronic myeloid leukemia")
+        assert chosen is not None and chosen["id"] == "MONDO:0011996"
+
+    def test_empty_pool_falls_back_to_overall_top(self):
+        """No canonical-namespace candidate -> honest fallback to the overall top-scored row."""
+        rows = [_row("UMLS:X", 3.0, "foo"), _row("CHV:Y", 2.0, "foo")]
+        chosen = KestrelHybridSearchAnnotator._select_canonical(rows, MET, "foo")
+        assert chosen is not None and chosen["id"] == "UMLS:X"
+
+    def test_empty_results_returns_none(self):
+        assert KestrelHybridSearchAnnotator._select_canonical([], MET, "foo") is None
+
+    def test_homonym_disambiguated_by_name_or_synonym(self):
+        """Multiple CHEBI rows; the one matching the query by name (or synonym) wins over higher-scored ones."""
+        rows = [
+            _row("CHEBI:29987", 1.44, "glutamate(2-)"),
+            _row("CHEBI:14321", 1.44, "glutamate(1-)", synonyms=["glutamate"]),  # synonym match
+        ]
+        chosen = KestrelHybridSearchAnnotator._select_canonical(rows, MET, "glutamate")
+        assert chosen is not None and chosen["id"] == "CHEBI:14321"
+
+
+def _annotate(rows, term, preferred_prefixes):
+    ann = KestrelHybridSearchAnnotator()
+    return ann.get_annotations(
+        {"name": term},
+        "name",
+        "biolink:SmallMolecule",
+        prefer_human=False,
+        preferred_prefixes=preferred_prefixes,
+        cache={term: rows},
+    )[ann.slug]
+
+
+class TestCanonicalWiring:
+    def test_canonical_chosen_and_tagged(self):
+        rows = [_row("UMLS:C0022818", 4.89, "Kynurenine"), _row("CHEBI:28683", 2.50, "kynurenine")]
+        annotations = _annotate(rows, "kynurenine", MET)
+        assert "28683" in annotations.get("CHEBI", {})
+        assert annotations["CHEBI"]["28683"].get("resolved_via") == "canonical_preference"
+        assert "C0022818" not in annotations.get("UMLS", {})
+
+    def test_no_canonical_keeps_top_untagged(self):
+        rows = [_row("UMLS:X", 3.0, "foo")]
+        annotations = _annotate(rows, "foo", MET)
+        assert "X" in annotations.get("UMLS", {})
+        assert "resolved_via" not in annotations["UMLS"]["X"]
+
+    def test_bulk_forwards_preferred_prefixes(self):
+        """get_annotations_bulk must forward preferred_prefixes to the per-row re-dispatch (else a no-op)."""
+        import pandas as pd
+
+        rows = [_row("UMLS:C0022818", 4.89, "Kynurenine"), _row("CHEBI:28683", 2.50, "kynurenine")]
+        ann = KestrelHybridSearchAnnotator()
+        with patch.object(ann, "_kestrel_hybrid_search", return_value={"kynurenine": rows}):
+            out = ann.get_annotations_bulk(
+                pd.DataFrame({"name": ["kynurenine"]}),
+                "name",
+                "biolink:SmallMolecule",
+                prefer_human=False,
+                preferred_prefixes=MET,
+            )
+        assert "28683" in out.iloc[0][ann.slug].get("CHEBI", {})

--- a/tests/test_kestrel_hybrid_canonical.py
+++ b/tests/test_kestrel_hybrid_canonical.py
@@ -25,8 +25,8 @@ class TestSelectCanonical:
             _row("CHEBI:28683", 2.50, "kynurenine"),
             _row("CHEBI:16946", 2.49, "L-kynurenine"),
         ]
-        chosen = KestrelHybridSearchAnnotator._select_canonical(rows, MET, "kynurenine")
-        assert chosen is not None and chosen["id"] == "CHEBI:28683"
+        chosen, is_canonical = KestrelHybridSearchAnnotator._select_canonical(rows, MET, "kynurenine")
+        assert chosen is not None and chosen["id"] == "CHEBI:28683" and is_canonical
 
     def test_name_mismatch_takes_top_scored_canonical(self):
         """CML: no MONDO name-matches the colloquial query -> the top-scored MONDO is chosen."""
@@ -35,17 +35,23 @@ class TestSelectCanonical:
             _row("MONDO:0011996", 2.50, "chronic myelogenous leukemia, BCR-ABL1 positive"),
             _row("MONDO:0004643", 1.50, "myeloid leukemia"),
         ]
-        chosen = KestrelHybridSearchAnnotator._select_canonical(rows, {"MONDO"}, "chronic myeloid leukemia")
-        assert chosen is not None and chosen["id"] == "MONDO:0011996"
+        chosen, is_canonical = KestrelHybridSearchAnnotator._select_canonical(
+            rows, {"MONDO"}, "chronic myeloid leukemia"
+        )
+        assert chosen is not None and chosen["id"] == "MONDO:0011996" and is_canonical
 
-    def test_empty_pool_falls_back_to_overall_top(self):
-        """No canonical-namespace candidate -> honest fallback to the overall top-scored row."""
+    def test_lowercase_kg_prefix_still_matches(self):
+        """A differently-cased KG namespace must still be recognized as canonical (case-insensitive filter)."""
+        rows = [_row("UMLS:X", 4.0, "thing"), _row("chebi:28683", 2.0, "thing")]
+        chosen, is_canonical = KestrelHybridSearchAnnotator._select_canonical(rows, MET, "thing")
+        assert chosen is not None and chosen["id"] == "chebi:28683" and is_canonical
+
+    def test_fallback_paths_are_not_canonical(self):
+        """Empty pool -> honest top-scored fallback (not canonical); empty results -> (None, False)."""
         rows = [_row("UMLS:X", 3.0, "foo"), _row("CHV:Y", 2.0, "foo")]
-        chosen = KestrelHybridSearchAnnotator._select_canonical(rows, MET, "foo")
-        assert chosen is not None and chosen["id"] == "UMLS:X"
-
-    def test_empty_results_returns_none(self):
-        assert KestrelHybridSearchAnnotator._select_canonical([], MET, "foo") is None
+        chosen, is_canonical = KestrelHybridSearchAnnotator._select_canonical(rows, MET, "foo")
+        assert chosen is not None and chosen["id"] == "UMLS:X" and not is_canonical
+        assert KestrelHybridSearchAnnotator._select_canonical([], MET, "foo") == (None, False)
 
     def test_homonym_disambiguated_by_name_or_synonym(self):
         """Multiple CHEBI rows; the one matching the query by name (or synonym) wins over higher-scored ones."""
@@ -53,7 +59,7 @@ class TestSelectCanonical:
             _row("CHEBI:29987", 1.44, "glutamate(2-)"),
             _row("CHEBI:14321", 1.44, "glutamate(1-)", synonyms=["glutamate"]),  # synonym match
         ]
-        chosen = KestrelHybridSearchAnnotator._select_canonical(rows, MET, "glutamate")
+        chosen, _ = KestrelHybridSearchAnnotator._select_canonical(rows, MET, "glutamate")
         assert chosen is not None and chosen["id"] == "CHEBI:14321"
 
 


### PR DESCRIPTION
## Summary

Stage-2 promotion to Phenome-Health `dev` of two pieces of work (validated and Greptile-reviewed on the
fork, PRs trentleslie/biomapper2#7 and #8):

1. **Canonical-namespace preference** (`prefer_canonical`, default-on) — generalizes the shipped
   `prefer_human` mechanism. Within a Biolink category, hybrid-search ranks across all namespaces at once,
   so a same-text non-canonical node (UMLS/ICD/KEGG/PANTHER) often outranks the canonical one (CHEBI/HMDB/RM
   for metabolites, MONDO for disease). `_select_canonical` prefers the canonical-namespace candidate that
   matches the query; honest top-scored fallback on a miss. Gene/protein path unchanged.
2. **Gene gold-set fix** — relaxes `test_human_gene_gold_set.py` to assert **clique membership** instead of
   exact CURIE. The drug-conflated genes can't yield `chosen_kg_id == NCBIGene:X` because the KG's
   canonicalize step collapses them into their drug clique (CALCA -> CHEBI:3306 "calcitonin", GH1 ->
   UNII "SOMATROPIN"); the clique still carries the NCBIGene + HGNC. **This unblocks the dev->main release
   CI (PR #70), which currently fails on the unsatisfiable exact-CURIE assertion.**

## Design validated against live Kestrel data (2026-06-18)
- Canonical nodes legitimately score ~2x below the conflated top hit, so there is **no score-margin guard**
  — the namespace filter + identity match is the discriminator.
- Disease is in scope (MONDO outranked even under `category_filter=biolink:Disease`).

## Changes
- `config`: `CATEGORY_PREFERRED_NAMESPACES` (real Kestrel prefixes — `RM`, not `REFMET`).
- `kestrel_hybrid`: `_select_canonical` (returns `(row, is_canonical)`, case-insensitive filter); bulk path
  forwards `preferred_prefixes`.
- `annotation_engine`: per-category preferred-prefix resolution via `get_descendants`, gated off for
  gene/protein; unions overlapping policies.
- API: `prefer_canonical: bool = True` on `MappingOptions`, threaded through routes/Mapper.
- Tests: 15 new offline unit tests + the relaxed gene gold set; ruff/black/pyright clean.

## ⚠️ Pre-merge gates
1. **Run the gold-set on the dev deployment** — `chosen_kg_id` is the resolver's CURIE-vote output, so the
   offline tests prove `_select_canonical` picks the right row but only the live gold-set proves the final
   node flips. (bmt blocks the full `Mapper` locally.)
2. **Consumer-impact audit** — `prefer_canonical=True` shifts returned `primary_curie` for affected
   metabolite/disease queries; grep kraken/biomapper-ui for pinned CURIEs before the default-on merge.

## Known follow-ups (deferred)
- 20x bulk candidate window for metabolite/disease dataset jobs (intended; confirm Kestrel/latency tolerance).
- `resolved_via` provenance survives only in raw `assigned_ids`, not `chosen_kg_id`.
- Config-drift tripwire for prefix renames / upstream de-conflation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
