### PR TITLE
Study: annotation-reranking ablation harness (gates Phase 3 LLM reranker)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ cache/
 
 # Serena AI tool
 .serena/
+
+# Annotation-reranking run artifacts (timestamped, never committed)
+studies/annotation_reranking/runs/

--- a/docs/plans/2026-07-06-002-feat-annotation-reranking-harness-plan.md
+++ b/docs/plans/2026-07-06-002-feat-annotation-reranking-harness-plan.md
@@ -1,0 +1,1191 @@
+# Annotation-Reranking Ablation Harness — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a self-contained harness that retrieves top-N metabolite candidate nodes from Kestrel, runs deterministic + LLM rerankers over them, and scores each reranker on independent-label and RM-uninformative subsets — producing the data that gates biomapper2 Phase 3 (LLM reranker tier) and feeds the BioMapper preprint.
+
+**Architecture:** A new `studies/annotation_reranking/` package inside the biomapper2 repo (importable under the same uv venv). It reuses biomapper2's Kestrel client directly (`_kestrel_hybrid_search` + node enrichment), implements rerankers as small pure functions behind one `Reranker` protocol, calls models through one unified `call_model()` (OpenAI SDK → OpenRouter for open models; native Anthropic/OpenAI SDKs for frontier), and always saves full per-item results to a timestamped path. A mandatory **Phase 0** measures RM-uninformative regime sizes before any model spend.
+
+**Tech Stack:** Python ≥3.10, uv, pandas, requests (via biomapper2's `kestrel_request`), pytest, `openai` SDK (for OpenRouter + GPT), `anthropic` SDK (Opus/Sonnet), `statsmodels` or hand-rolled exact stats (McNemar, Wilson CI).
+
+## Global Constraints
+
+- **Python ≥ 3.10** (biomapper2 `pyproject.toml`). Run everything via `uv run …` from the repo root.
+- **Never mutate ground truth.** `chebi_disagreements_cat.csv` and `analyze.py` in the vault dir are read-only inputs. Copy/hash them; do not edit.
+- **Kestrel access:** `KESTREL_API_KEY` (header `X-API-Key`) and `KESTREL_API_URL` (default `https://kestrel.nathanpricelab.com/api`) are read by `biomapper2.config`. `HYBRID_SEARCH_LIMIT = 20` is the default `top_n`.
+- **Model keys:** `OPENROUTER_API_KEY` lives in `~/.config/model-ablation/env` (chmod 600; `source` it). Native Anthropic/OpenAI keys via their standard env vars. **Read keys inline; never echo or commit them.**
+- **Reproducibility SOP (mandatory, not a flag):** every run saves full per-item results to `studies/annotation_reranking/runs/<UTC-stamp>/` **by default** and prints the path on completion. `--out` only *overrides* the path. Each run's `manifest.json` pins: CSV content hash (SHA-256 of the file bytes), exact model ids/versions, seeds, `top_n`, temperature, quantization note ("OpenRouter fp8, NOT local Q4" for open models), and hardware string.
+- **Determinism:** `temperature=0` and a fixed seed for every model call. Counterbalance candidate ordering across seeds (position-bias control).
+- **RM-anchor definition:** pick the candidate whose enriched `equivalent_ids` contains a RefMet id (prefix `RM:`); if none, fall back to top score; break ties deterministically (lowest CURIE string). This is the free baseline to beat.
+- **Scope boundary:** this harness is a *study*. It deliberately calls `_kestrel_hybrid_search` directly rather than the production `get_annotations` path, so it does **not** depend on Phase 1 production wiring. Reranker functions live in the study package; migrating them to `src/biomapper2/core/rerankers/` is Phase 1/3 work, out of scope here.
+
+---
+
+## Revision 2026-07-08 — baseline swap, InChIKey labels, retrieval ceiling (AUTHORITATIVE)
+
+The companion reranker design was revised 2026-07-08 (`docs/plans/2026-07-06-001-feat-topn-pluggable-reranker-design.md`, "Revision 2026-07-08"). Three changes flow into this plan. **This section is authoritative wherever it conflicts with the task text below.** The infra (retrieval, model-call, orchestrator, reproducibility) is unchanged.
+
+**Change A — primary deterministic baseline is `source_weight_guard`, not `rm_anchor`.** `rm_anchor` is retired as the metabolite default (circular: `RM:` *is* RefMet). It stays in the matrix **only to demonstrate the circularity**. The rule to beat is guarded source-weighting with a layered InChIKey resolver.
+
+**Change B — headline labels come from InChIKey first-block connectivity** (non-circular), not the ~13 hand-triaged cases (which become a cross-check). Stereo/protonation cases (same connectivity) are not InChIKey-adjudicable → excluded from the skill set as `expert_needed`.
+
+**Change C — tag retrievability and report accuracy conditioned on it.** Measured ceiling: 45/172 correct nodes absent at `limit=200`. The LLM skill set = present-but-misranked + flagged-divergent cases only.
+
+### New module: `studies/annotation_reranking/inchikey_resolver.py` (do before Task 4)
+
+**Interfaces produced:**
+- `inchikey_block(node_id: str, name: str) -> str | None` — layered, cached by `name`, each layer timeout-guarded and returning `None` on error (never raises): (1) KG `equivalent_ids` with `INCHIKEY` prefix; (2) Metabolomics Workbench `GET /rest/refmet/name/{name}/inchi_key`; (3) PubChem `GET /rest/pug/compound/name/{name}/property/InChIKey/JSON`. Returns the **first block** (substring before the first `-`).
+- `connectivity_match(id_a, name_a, id_b, name_b) -> bool | None` — `True` if both blocks resolve and match, `False` if both resolve and differ, `None` if either is unresolvable.
+
+Mirror the resolver spec's logic; a `# CONSOLIDATE: replace with core.resolver._connectivity_match once Phase 1b merges` comment marks the intended dedup. Tests mock all three network layers and assert the layer order (KG hit skips MW/PubChem; KG miss falls through to MW then PubChem; all-miss → `None`).
+
+### Change to the `Reranker` protocol (Task 4) — carries case context + review flag
+
+`select(candidates: list[Candidate], case: EvalCase | None = None) -> tuple[str | None, str | None]` → `(selected_id, review_flag)`. Deterministic `top1`/`rm_anchor` ignore `case` and return `flag=None`. `RerankResult` gains `review_flag: str | None`. `score_case` (Task 8) unpacks the tuple and stores the flag.
+
+### New reranker: `SourceWeightGuardReranker` (primary baseline, in `deterministic.py`)
+
+```python
+class SourceWeightGuardReranker:
+    name = "source_weight_guard"
+    def __init__(self, connectivity_fn):        # inject connectivity_match for testability
+        self._match = connectivity_fn
+    def select(self, candidates, case=None):
+        if not candidates:
+            return None, "empty_candidates"
+        majority = max(candidates, key=lambda c: c.score)          # study proxy for the vote
+        if case is None or not case.refmet_id:
+            return majority.id, None
+        refmet_curie = f"CHEBI:{case.refmet_id}"
+        refmet = next((c for c in candidates if c.id == refmet_curie), None)
+        if refmet is None or refmet.id == majority.id:
+            return majority.id, None
+        same = self._match(refmet.id, refmet.name, majority.id, majority.name)
+        if same is True:  return refmet.id, None                    # same molecule, silent
+        if same is False: return refmet.id, "divergent_refmet"      # error-prone bucket → flag
+        return majority.id, "conflict_no_structure"                 # unresolved → keep majority + flag
+```
+Tests (mock `connectivity_fn`): refmet-absent → majority/None; same-connectivity → refmet/None; different → refmet/`divergent_refmet`; unresolved → majority/`conflict_no_structure`. **Note the `majority = top-score` proxy** (the study has no multi-annotator vote); record this limitation in the README.
+
+### Amendments to existing tasks
+
+- **Task 1 (dataset):** add `inchikey_block_correct: str | None` and `retrievable: bool | None` fields to `EvalCase` (populated later, default `None`). Add `label_source` values `"inchikey_connectivity"` and `"expert_needed"`. Keep the n=2 `rm_anchor`-circularity test — it now documents *why* `rm_anchor` was demoted, not the headline path.
+- **Task 3 (Phase 0):** replace RM-regime counting with **(i) retrievability** — is the correct node (InChIKey-labelled, or `refmet_id`) in the top-`top_n` window? Reproduce the 45/172-absent@200 finding; **(ii) divergence** — of retrievable cases, how many does `source_weight_guard` flag (`divergent_refmet` / `conflict_no_structure`). Report both. Gate unchanged: STOP and report before model spend.
+- **Task 4:** implement `top1`, `rm_anchor` (reference), **and `source_weight_guard` (primary)** under the new tuple-returning protocol.
+- **Task 5 (LLM) / Task 7 (scoring):** the LLM skill set is `retrievable AND (label_source=="inchikey_connectivity") AND source_weight_guard flagged-or-wrong`. Report accuracy **conditioned on retrievability**; same-connectivity cases are excluded (handled deterministically). RM-blinding is retained but secondary (baseline is no longer RM-based).
+- **Task 6 / Task 8 / Task 9:** unchanged except `RerankResult.review_flag` threads through `results.jsonl`, and the README states Change A/B/C + the `majority=top-score` proxy + the InChIKey non-adjudicable (stereo/protonation) caveat.
+
+---
+
+## File Structure
+
+```
+studies/annotation_reranking/
+  __init__.py
+  models_data.py        # Candidate, EvalCase, RerankResult dataclasses (no I/O)
+  dataset.py            # load CSV → EvalCase[]; derive independent labels; content hash
+  retrieval.py          # top-N fetch via _kestrel_hybrid_search + equivalent_ids enrichment
+  inchikey_resolver.py  # [Rev 2026-07-08] layered InChIKey block resolver (KG→MW→PubChem)
+  regimes.py            # [Rev 2026-07-08] retrievability + source_weight_guard divergence tagging
+  phase0.py             # measure + report regime sizes (the gate before model spend)
+  rerankers/
+    __init__.py
+    base.py             # Reranker protocol + registry
+    deterministic.py    # top1, rm_anchor
+    llm.py              # prompt build (+ RM-blinding), response parse, LLM reranker
+  model_call.py         # roster + unified call_model() → (text, cost_usd, latency_s)
+  scoring.py            # per-regime accuracy, Wilson CI, McNemar exact, discordant counts
+  run.py                # orchestrate full matrix; timestamped output by default; manifest
+  README.md             # how to run + reproducibility SOP
+  runs/                 # gitignored output (created at runtime)
+tests/studies/annotation_reranking/
+  test_dataset.py
+  test_retrieval.py
+  test_regimes.py
+  test_deterministic.py
+  test_llm.py
+  test_model_call.py
+  test_scoring.py
+  test_run.py
+```
+
+**Task dependency order:** 1 → 2 → 3 (Phase 0 gate) → 4 → 5 → 6 → 7 → 8 → 9. Tasks 4–7 are independent of each other once 1–2 exist and may be built in any order; 8 depends on all.
+
+---
+
+### Task 1: Study package scaffold + data models + dataset loader
+
+**Files:**
+- Create: `studies/annotation_reranking/__init__.py`
+- Create: `studies/annotation_reranking/models_data.py`
+- Create: `studies/annotation_reranking/dataset.py`
+- Create: `studies/__init__.py` (empty, makes `studies` importable)
+- Test: `tests/studies/annotation_reranking/test_dataset.py`
+- Reference (read-only input): `/home/trentleslie/Documents/Trent's Vault/Active 🎯/Work/Projects/biomapper2 - refmet ChEBI analysis/chebi_disagreements_cat.csv`
+
+**Interfaces:**
+- Produces:
+  - `Candidate(id: str, score: float, name: str, synonyms: list[str], prefixes: list[str], equivalent_ids: list[str])` — a dataclass in `models_data.py`.
+  - `EvalCase(name: str, level: str, refmet_id: str, refmet_name: str, biomapper_ids: list[str], biomapper_name: str, category: str, correct_id: str | None, label_source: str)` — `correct_id` is the CURIE (`CHEBI:<n>`) of the independently-adjudicated right answer, or `None` when only RefMet-agreement is available; `label_source ∈ {"independent_refmet_error", "independent_biomapper_error", "refmet_agreement"}`.
+  - `load_eval_cases(csv_path: str) -> list[EvalCase]`
+  - `independent_cases(cases: list[EvalCase]) -> list[EvalCase]` (those with `label_source` starting `"independent_"`)
+  - `dataset_sha256(csv_path: str) -> str`
+  - Module constants `TRUE_BIOMAPPER_ERRORS: set[str]` and `REFMET_ERRORS: set[str]` — the 11 + 2 case names copied verbatim from `analyze.py`.
+
+**Key derivation rule (the n=2 insight, encode it explicitly):**
+- CSV `refmet_id` / `biomapper_id` are bare ChEBI integers (biomapper_id may be pipe-delimited, e.g. `27596|50599`). Normalize to `CHEBI:<n>` CURIEs.
+- For a name in `TRUE_BIOMAPPER_ERRORS`: BioMapper was wrong → `correct_id = CHEBI:<refmet_id>`, `label_source = "independent_biomapper_error"`.
+- For a name in `REFMET_ERRORS`: RefMet was wrong → `correct_id = CHEBI:<first biomapper_id>`, `label_source = "independent_refmet_error"`.
+- Otherwise: `correct_id = None`, `label_source = "refmet_agreement"` (RefMet's node; use only for agreement reporting, never as skill).
+
+- [ ] **Step 1: Confirm the pinned error-case names in `analyze.py`**
+
+Run: `grep -nA14 "TRUE_BIOMAPPER_ERRORS\|REFMET_ERRORS" "/home/trentleslie/Documents/Trent's Vault/Active 🎯/Work/Projects/biomapper2 - refmet ChEBI analysis/analyze.py"`
+Expected: the two dicts. Copy the exact key strings (11 + 2) into `TRUE_BIOMAPPER_ERRORS` / `REFMET_ERRORS` in `dataset.py`. (These are the ground-truth case names — the plan depends on them matching the CSV `name` column exactly.)
+
+- [ ] **Step 2: Write the failing test**
+
+```python
+# tests/studies/annotation_reranking/test_dataset.py
+from studies.annotation_reranking.dataset import (
+    load_eval_cases, independent_cases, dataset_sha256,
+    TRUE_BIOMAPPER_ERRORS, REFMET_ERRORS,
+)
+
+CSV = "/home/trentleslie/Documents/Trent's Vault/Active 🎯/Work/Projects/biomapper2 - refmet ChEBI analysis/chebi_disagreements_cat.csv"
+
+def test_loads_all_172_rows():
+    cases = load_eval_cases(CSV)
+    assert len(cases) == 172
+
+def test_error_case_counts():
+    assert len(TRUE_BIOMAPPER_ERRORS) == 11
+    assert len(REFMET_ERRORS) == 2
+
+def test_independent_label_partition():
+    cases = load_eval_cases(CSV)
+    indep = independent_cases(cases)
+    # 11 biomapper-error + 2 refmet-error == 13 independently-labeled cases
+    assert len(indep) == 13
+    bm = [c for c in indep if c.label_source == "independent_biomapper_error"]
+    rm = [c for c in indep if c.label_source == "independent_refmet_error"]
+    assert len(bm) == 11 and len(rm) == 2
+    # every independent case has a concrete correct CURIE
+    assert all(c.correct_id and c.correct_id.startswith("CHEBI:") for c in indep)
+
+def test_biomapper_error_correct_id_is_refmet_node():
+    # the n=2 insight: on the 11 BM-errors, correct == RefMet's node,
+    # so rm_anchor (picks RM-bearing == RefMet node) is right by construction.
+    cases = {c.name: c for c in load_eval_cases(CSV)}
+    for name in TRUE_BIOMAPPER_ERRORS:
+        c = cases[name]
+        assert c.correct_id == f"CHEBI:{c.refmet_id}"
+
+def test_dataset_hash_is_stable_hex():
+    h = dataset_sha256(CSV)
+    assert len(h) == 64 and all(ch in "0123456789abcdef" for ch in h)
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `uv run pytest tests/studies/annotation_reranking/test_dataset.py -v`
+Expected: FAIL with `ModuleNotFoundError: studies.annotation_reranking.dataset`
+
+- [ ] **Step 4: Implement `models_data.py`**
+
+```python
+# studies/annotation_reranking/models_data.py
+from dataclasses import dataclass, field
+
+@dataclass
+class Candidate:
+    id: str                       # CURIE, e.g. "CHEBI:28683"
+    score: float                  # Kestrel hybrid score (0–5)
+    name: str
+    synonyms: list[str] = field(default_factory=list)
+    prefixes: list[str] = field(default_factory=list)
+    equivalent_ids: list[str] = field(default_factory=list)  # enriched via get-nodes
+
+    def has_refmet(self) -> bool:
+        return any(e.startswith("RM:") for e in self.equivalent_ids)
+
+@dataclass
+class EvalCase:
+    name: str
+    level: str
+    refmet_id: str
+    refmet_name: str
+    biomapper_ids: list[str]
+    biomapper_name: str
+    category: str
+    correct_id: str | None
+    label_source: str
+
+@dataclass
+class RerankResult:
+    case_name: str
+    reranker: str
+    model: str | None
+    selected_id: str | None
+    correct_id: str | None
+    label_source: str
+    regime: str
+    is_correct: bool | None       # None when label_source == "refmet_agreement"
+    cost_usd: float
+    latency_s: float
+    error: str | None = None      # off-list / parse / api failure marker
+```
+
+- [ ] **Step 5: Implement `dataset.py`**
+
+```python
+# studies/annotation_reranking/dataset.py
+import csv
+import hashlib
+from studies.annotation_reranking.models_data import EvalCase
+
+# Copy the exact 11 + 2 names from analyze.py (Step 1). Placeholder names below
+# MUST be replaced with the verified strings before this task is complete.
+TRUE_BIOMAPPER_ERRORS: set[str] = {
+    "(15:3)-anacardic acid", "2-hydroxypalmitate", "4-acetamidophenol",
+    "4-hydroxyhippurate", "4-methylbenzenesulfonate", "9-hydroxystearate",
+    "5_HpEPE__4_55", "2-Methylmaleate", "laurylcarnitine (C12)",
+    "myristoylcarnitine (C14)", "glycerophosphoinositol*",
+}
+REFMET_ERRORS: set[str] = {
+    "6-shogaol", "Diethyl 2-methyl-3-oxosuccinate",
+}
+
+def _curie(raw: str) -> str:
+    raw = raw.strip()
+    return raw if raw.startswith("CHEBI:") else f"CHEBI:{raw}"
+
+def load_eval_cases(csv_path: str) -> list[EvalCase]:
+    cases: list[EvalCase] = []
+    with open(csv_path, newline="", encoding="utf-8") as fh:
+        for row in csv.DictReader(fh):
+            name = row["name"]
+            bm_ids = [_curie(x) for x in row["biomapper_id"].split("|") if x.strip()]
+            if name in TRUE_BIOMAPPER_ERRORS:
+                correct, src = _curie(row["refmet_id"]), "independent_biomapper_error"
+            elif name in REFMET_ERRORS:
+                correct, src = (bm_ids[0] if bm_ids else None), "independent_refmet_error"
+            else:
+                correct, src = None, "refmet_agreement"
+            cases.append(EvalCase(
+                name=name, level=row["level"], refmet_id=row["refmet_id"],
+                refmet_name=row["refmet_name"], biomapper_ids=bm_ids,
+                biomapper_name=row["biomapper_name"], category=row["category"],
+                correct_id=correct, label_source=src,
+            ))
+    return cases
+
+def independent_cases(cases: list[EvalCase]) -> list[EvalCase]:
+    return [c for c in cases if c.label_source.startswith("independent_")]
+
+def dataset_sha256(csv_path: str) -> str:
+    with open(csv_path, "rb") as fh:
+        return hashlib.sha256(fh.read()).hexdigest()
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `uv run pytest tests/studies/annotation_reranking/test_dataset.py -v`
+Expected: PASS (5 tests). If `test_biomapper_error_correct_id_is_refmet_node` fails, a name in `TRUE_BIOMAPPER_ERRORS` doesn't match the CSV — fix the copied string, don't relax the test.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add studies/ tests/studies/
+git commit -m "feat(study): eval-case dataset loader + independent-label partition"
+```
+
+---
+
+### Task 2: Top-N candidate retrieval + equivalent_ids enrichment
+
+**Files:**
+- Create: `studies/annotation_reranking/retrieval.py`
+- Test: `tests/studies/annotation_reranking/test_retrieval.py`
+- Reference: `src/biomapper2/core/annotators/kestrel_hybrid.py`, `src/biomapper2/core/linker.py`, `src/biomapper2/config.py`
+
+**Interfaces:**
+- Consumes: `Candidate` from Task 1.
+- Produces: `fetch_candidates(name: str, category: str, top_n: int = 20) -> list[Candidate]` — returns up to `top_n` scored candidates, each enriched with `equivalent_ids`.
+
+- [ ] **Step 1: Confirm the exact biomapper2 symbols**
+
+Run: `grep -n "class \|def _kestrel_hybrid_search\|def get_equivalent" "src/biomapper2/core/annotators/kestrel_hybrid.py" "src/biomapper2/core/linker.py"`
+Expected: the annotator class name (e.g. `KestrelHybridAnnotator`), the static `_kestrel_hybrid_search(search_text, category, prefixes, limit=10)`, and the equivalent-ids fetch in `linker.py`. Record the confirmed names; use them below in place of `<AnnotatorClass>` / `<get_equivalent_ids>`.
+
+- [ ] **Step 2: Write the failing test (mock the network)**
+
+```python
+# tests/studies/annotation_reranking/test_retrieval.py
+from unittest.mock import patch
+from studies.annotation_reranking import retrieval
+from studies.annotation_reranking.models_data import Candidate
+
+FAKE_SEARCH = {"1-methylhistidine": [
+    {"id": "CHEBI:70958", "score": 4.9, "name": "1-methylhistidine", "synonyms": []},
+    {"id": "CHEBI:27596", "score": 4.1, "name": "N(pros)-methyl-L-histidine", "synonyms": []},
+]}
+FAKE_EQUIV = {"CHEBI:70958": ["RM:0001", "HMDB:0000001"], "CHEBI:27596": ["HMDB:0000479"]}
+
+def test_fetch_returns_enriched_candidates():
+    with patch.object(retrieval, "_raw_hybrid_search", return_value=FAKE_SEARCH), \
+         patch.object(retrieval, "_fetch_equivalent_ids", return_value=FAKE_EQUIV):
+        cands = retrieval.fetch_candidates("1-methylhistidine", "metabolite", top_n=20)
+    assert [c.id for c in cands] == ["CHEBI:70958", "CHEBI:27596"]
+    assert isinstance(cands[0], Candidate)
+    assert cands[0].equivalent_ids == ["RM:0001", "HMDB:0000001"]
+    assert cands[0].has_refmet() and not cands[1].has_refmet()
+
+def test_top_n_is_passed_through():
+    captured = {}
+    def spy(text, category, prefixes, limit):
+        captured["limit"] = limit
+        return {text: []}
+    with patch.object(retrieval, "_raw_hybrid_search", side_effect=spy), \
+         patch.object(retrieval, "_fetch_equivalent_ids", return_value={}):
+        retrieval.fetch_candidates("x", "metabolite", top_n=15)
+    assert captured["limit"] == 15
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `uv run pytest tests/studies/annotation_reranking/test_retrieval.py -v`
+Expected: FAIL (`AttributeError`/`ModuleNotFoundError` on `retrieval`).
+
+- [ ] **Step 4: Implement `retrieval.py`**
+
+```python
+# studies/annotation_reranking/retrieval.py
+from biomapper2.core.annotators.kestrel_hybrid import <AnnotatorClass>  # from Step 1
+from biomapper2.core.linker import <get_equivalent_ids>                 # from Step 1
+from studies.annotation_reranking.models_data import Candidate
+
+def _raw_hybrid_search(text: str, category: str, prefixes, limit: int) -> dict:
+    # Bypasses production get_annotations (which hardcodes limit=1) on purpose.
+    return <AnnotatorClass>._kestrel_hybrid_search(text, category, prefixes, limit=limit)
+
+def _fetch_equivalent_ids(ids: list[str]) -> dict[str, list[str]]:
+    # Wrap linker's get-nodes call; return {curie: [equivalent CURIEs]}.
+    return <get_equivalent_ids>(ids)
+
+def fetch_candidates(name: str, category: str, top_n: int = 20) -> list[Candidate]:
+    raw = _raw_hybrid_search(name, category, None, limit=top_n).get(name, [])
+    ids = [r["id"] for r in raw]
+    equiv = _fetch_equivalent_ids(ids) if ids else {}
+    return [
+        Candidate(
+            id=r["id"], score=float(r["score"]), name=r["name"],
+            synonyms=r.get("synonyms", []), prefixes=r.get("prefixes", []),
+            equivalent_ids=equiv.get(r["id"], []),
+        )
+        for r in raw
+    ]
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `uv run pytest tests/studies/annotation_reranking/test_retrieval.py -v`
+Expected: PASS (2 tests).
+
+- [ ] **Step 6: Add a live smoke check (marked external, skipped by default)**
+
+```python
+# append to test_retrieval.py
+import os, pytest
+
+@pytest.mark.external
+@pytest.mark.skipif(not os.getenv("KESTREL_API_KEY"), reason="needs KESTREL_API_KEY")
+def test_live_fetch_one_case():
+    cands = retrieval.fetch_candidates("1-methylhistidine", "metabolite", top_n=20)
+    assert 1 <= len(cands) <= 20
+    assert all(c.id.startswith("CHEBI:") for c in cands)
+```
+
+Run: `uv run pytest tests/studies/annotation_reranking/test_retrieval.py -v -m external` (only when the API key + network are available). Expected: PASS or skip.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add studies/annotation_reranking/retrieval.py tests/studies/annotation_reranking/test_retrieval.py
+git commit -m "feat(study): top-N Kestrel retrieval with equivalent_ids enrichment"
+```
+
+---
+
+### Task 3: Regime classification + Phase 0 gate
+
+**Files:**
+- Create: `studies/annotation_reranking/regimes.py`
+- Create: `studies/annotation_reranking/phase0.py`
+- Test: `tests/studies/annotation_reranking/test_regimes.py`
+
+**Interfaces:**
+- Consumes: `Candidate`, `EvalCase`, `fetch_candidates`.
+- Produces:
+  - `classify_regime(candidates: list[Candidate]) -> str` → `"a_no_rm"` (no RM-bearing candidate), `"b_multi_rm"` (≥2 RM-bearing candidates → tie/ambiguous), or `"informative"` (exactly one RM-bearing candidate).
+  - `run_phase0(csv_path: str, top_n: int, out_dir: str) -> dict` → writes `phase0_regimes.json` and returns `{"a_no_rm": int, "b_multi_rm": int, "informative": int, "n_independent_rm_wrong": int, ...}`.
+
+**Why this is a gate:** `run_phase0` counts how many of the 172 cases land in RM-uninformative regimes (a/b) — the only place beyond the 2 RefMet-error cases where an LLM can out-skill `rm_anchor`. It also reports `n_independent_rm_wrong` (cases where `rm_anchor`'s pick ≠ `correct_id`). If regimes a+b and `n_independent_rm_wrong` are both tiny, the headline needs the ≥100-pair curated set before models are worth running.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/studies/annotation_reranking/test_regimes.py
+from studies.annotation_reranking.regimes import classify_regime
+from studies.annotation_reranking.models_data import Candidate
+
+def _c(cid, rm): return Candidate(id=cid, score=1.0, name=cid, equivalent_ids=(["RM:1"] if rm else []))
+
+def test_no_rm_candidate():
+    assert classify_regime([_c("CHEBI:1", False), _c("CHEBI:2", False)]) == "a_no_rm"
+
+def test_single_rm_candidate_is_informative():
+    assert classify_regime([_c("CHEBI:1", True), _c("CHEBI:2", False)]) == "informative"
+
+def test_multiple_rm_candidates():
+    assert classify_regime([_c("CHEBI:1", True), _c("CHEBI:2", True)]) == "b_multi_rm"
+
+def test_empty_list_is_no_rm():
+    assert classify_regime([]) == "a_no_rm"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/studies/annotation_reranking/test_regimes.py -v`
+Expected: FAIL (`ModuleNotFoundError`).
+
+- [ ] **Step 3: Implement `regimes.py`**
+
+```python
+# studies/annotation_reranking/regimes.py
+from studies.annotation_reranking.models_data import Candidate
+
+def classify_regime(candidates: list[Candidate]) -> str:
+    rm = [c for c in candidates if c.has_refmet()]
+    if len(rm) == 0:
+        return "a_no_rm"
+    if len(rm) >= 2:
+        return "b_multi_rm"
+    return "informative"
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/studies/annotation_reranking/test_regimes.py -v`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Implement `phase0.py` (uses live retrieval; run manually)**
+
+```python
+# studies/annotation_reranking/phase0.py
+import json, os
+from collections import Counter
+from studies.annotation_reranking.dataset import load_eval_cases, dataset_sha256
+from studies.annotation_reranking.retrieval import fetch_candidates
+from studies.annotation_reranking.regimes import classify_regime
+
+def run_phase0(csv_path: str, top_n: int, out_dir: str) -> dict:
+    os.makedirs(out_dir, exist_ok=True)
+    cases = load_eval_cases(csv_path)
+    regime_counts, rm_wrong, per_case = Counter(), 0, []
+    for c in cases:
+        cands = fetch_candidates(c.name, "metabolite", top_n=top_n)
+        regime = classify_regime(cands)
+        regime_counts[regime] += 1
+        rm_pick = next((x.id for x in cands if x.has_refmet()),
+                       (max(cands, key=lambda x: x.score).id if cands else None))
+        if c.correct_id and rm_pick != c.correct_id:
+            rm_wrong += 1
+        per_case.append({"name": c.name, "regime": regime, "rm_pick": rm_pick,
+                         "correct_id": c.correct_id, "label_source": c.label_source})
+    summary = {"top_n": top_n, "dataset_sha256": dataset_sha256(csv_path),
+               "n_cases": len(cases), **regime_counts,
+               "n_independent_rm_wrong": rm_wrong}
+    with open(os.path.join(out_dir, "phase0_regimes.json"), "w") as fh:
+        json.dump({"summary": summary, "per_case": per_case}, fh, indent=2)
+    print(f"[phase0] {summary}")
+    print(f"[phase0] wrote {out_dir}/phase0_regimes.json")
+    return summary
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add studies/annotation_reranking/regimes.py studies/annotation_reranking/phase0.py tests/studies/annotation_reranking/test_regimes.py
+git commit -m "feat(study): regime classifier + Phase 0 gate measurement"
+```
+
+- [ ] **Step 7: DECISION GATE — run Phase 0 and report before building models**
+
+Run (needs `KESTREL_API_KEY`): `uv run python -c "from studies.annotation_reranking.phase0 import run_phase0; run_phase0('/home/trentleslie/Documents/Trent\\'s Vault/Active 🎯/Work/Projects/biomapper2 - refmet ChEBI analysis/chebi_disagreements_cat.csv', 20, 'studies/annotation_reranking/runs/phase0')"`
+Expected: prints regime counts + `n_independent_rm_wrong`. **Stop and report these numbers to Trent.** If `a_no_rm + b_multi_rm + n_independent_rm_wrong` is small (single digits), flag that the skill-revealing set is tiny and the ≥100-pair curated label set is a prerequisite before the full model matrix is worth its cost. Do not silently proceed.
+
+---
+
+### Task 4: Deterministic rerankers (top-1, rm_anchor)
+
+**Files:**
+- Create: `studies/annotation_reranking/rerankers/__init__.py`
+- Create: `studies/annotation_reranking/rerankers/base.py`
+- Create: `studies/annotation_reranking/rerankers/deterministic.py`
+- Test: `tests/studies/annotation_reranking/test_deterministic.py`
+
+**Interfaces:**
+- Consumes: `Candidate`.
+- Produces:
+  - `Reranker` = `Protocol` with `name: str` and `select(candidates: list[Candidate]) -> str | None`.
+  - `Top1Reranker()` and `RmAnchorReranker()` implementing it.
+  - `REGISTRY: dict[str, Reranker]` in `base.py` (deterministic entries registered here; LLM entries added in Task 5).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/studies/annotation_reranking/test_deterministic.py
+from studies.annotation_reranking.rerankers.deterministic import Top1Reranker, RmAnchorReranker
+from studies.annotation_reranking.models_data import Candidate
+
+def _c(cid, score, rm): return Candidate(id=cid, score=score, name=cid, equivalent_ids=(["RM:1"] if rm else []))
+
+def test_top1_picks_highest_score():
+    cands = [_c("CHEBI:2", 4.9, False), _c("CHEBI:9", 3.1, True)]
+    assert Top1Reranker().select(cands) == "CHEBI:2"
+
+def test_rm_anchor_prefers_rm_bearing_even_if_lower_score():
+    cands = [_c("CHEBI:2", 4.9, False), _c("CHEBI:9", 3.1, True)]
+    assert RmAnchorReranker().select(cands) == "CHEBI:9"
+
+def test_rm_anchor_falls_back_to_top_score_when_no_rm():
+    cands = [_c("CHEBI:2", 4.9, False), _c("CHEBI:3", 3.1, False)]
+    assert RmAnchorReranker().select(cands) == "CHEBI:2"
+
+def test_rm_anchor_breaks_ties_deterministically():
+    # two RM-bearing candidates → lowest CURIE string wins (stable, reproducible)
+    cands = [_c("CHEBI:50", 2.0, True), _c("CHEBI:27", 2.0, True)]
+    assert RmAnchorReranker().select(cands) == "CHEBI:27"
+
+def test_empty_returns_none():
+    assert Top1Reranker().select([]) is None
+    assert RmAnchorReranker().select([]) is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/studies/annotation_reranking/test_deterministic.py -v`
+Expected: FAIL (`ModuleNotFoundError`).
+
+- [ ] **Step 3: Implement `base.py` then `deterministic.py`**
+
+```python
+# studies/annotation_reranking/rerankers/base.py
+from typing import Protocol, runtime_checkable
+from studies.annotation_reranking.models_data import Candidate
+
+@runtime_checkable
+class Reranker(Protocol):
+    name: str
+    def select(self, candidates: list[Candidate]) -> str | None: ...
+
+REGISTRY: dict[str, "Reranker"] = {}
+
+def register(r: "Reranker") -> "Reranker":
+    REGISTRY[r.name] = r
+    return r
+```
+
+```python
+# studies/annotation_reranking/rerankers/deterministic.py
+from studies.annotation_reranking.models_data import Candidate
+from studies.annotation_reranking.rerankers.base import register
+
+class Top1Reranker:
+    name = "top1"
+    def select(self, candidates: list[Candidate]) -> str | None:
+        return max(candidates, key=lambda c: c.score).id if candidates else None
+
+class RmAnchorReranker:
+    name = "rm_anchor"
+    def select(self, candidates: list[Candidate]) -> str | None:
+        if not candidates:
+            return None
+        rm = [c for c in candidates if c.has_refmet()]
+        if rm:
+            return min(rm, key=lambda c: c.id).id      # deterministic tie-break
+        return max(candidates, key=lambda c: c.score).id
+
+register(Top1Reranker())
+register(RmAnchorReranker())
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/studies/annotation_reranking/test_deterministic.py -v`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add studies/annotation_reranking/rerankers/ tests/studies/annotation_reranking/test_deterministic.py
+git commit -m "feat(study): Reranker protocol + top1/rm_anchor deterministic rerankers"
+```
+
+---
+
+### Task 5: LLM reranker — prompt (with RM-blinding), parse, off-list handling
+
+**Files:**
+- Create: `studies/annotation_reranking/rerankers/llm.py`
+- Test: `tests/studies/annotation_reranking/test_llm.py`
+
+**Interfaces:**
+- Consumes: `Candidate`; `call_model` (Task 6) is injected, so this task tests prompt/parse in isolation with a stub callable.
+- Produces:
+  - `build_prompt(candidates: list[Candidate], blind_rm: bool) -> str`
+  - `parse_selection(text: str, candidates: list[Candidate]) -> str | None` (returns a candidate id present in the list, else `None` for off-list/malformed)
+  - `LlmReranker(model_name: str, call_fn, blind_rm: bool)` with `.name` = `f"llm:{model_name}{'/blind' if blind_rm else ''}"` and `.select(candidates) -> str | None`.
+
+**RM-blinding rule:** when `blind_rm=True`, strip any `equivalent_ids`/`prefixes` entry beginning `RM:` and drop the RefMet canonical name from the serialized candidate, so the model cannot key on the anchor feature.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/studies/annotation_reranking/test_llm.py
+from studies.annotation_reranking.rerankers.llm import build_prompt, parse_selection, LlmReranker
+from studies.annotation_reranking.models_data import Candidate
+
+def _c(cid, rm): return Candidate(id=cid, score=1.0, name=cid, equivalent_ids=(["RM:9", "HMDB:1"] if rm else ["HMDB:1"]))
+
+def test_blind_strips_rm_ids_from_prompt():
+    cands = [_c("CHEBI:1", True), _c("CHEBI:2", False)]
+    assert "RM:9" in build_prompt(cands, blind_rm=False)
+    assert "RM:9" not in build_prompt(cands, blind_rm=True)
+
+def test_parse_accepts_in_list_curie():
+    cands = [_c("CHEBI:1", True), _c("CHEBI:2", False)]
+    assert parse_selection("I choose CHEBI:2 because ...", cands) == "CHEBI:2"
+
+def test_parse_rejects_off_list_or_garbage():
+    cands = [_c("CHEBI:1", True)]
+    assert parse_selection("CHEBI:99999", cands) is None      # hallucinated / off-list
+    assert parse_selection("none of these", cands) is None
+
+def test_llm_reranker_uses_injected_call_fn():
+    cands = [_c("CHEBI:1", True), _c("CHEBI:2", False)]
+    stub = lambda model, prompt: ("CHEBI:2", 0.0, 0.0)  # (text, cost, latency)
+    r = LlmReranker("sonnet", call_fn=lambda m, p: stub(m, p)[0], blind_rm=True)
+    assert r.name == "llm:sonnet/blind"
+    assert r.select(cands) == "CHEBI:2"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/studies/annotation_reranking/test_llm.py -v`
+Expected: FAIL (`ModuleNotFoundError`).
+
+- [ ] **Step 3: Implement `llm.py`**
+
+```python
+# studies/annotation_reranking/rerankers/llm.py
+import re
+from studies.annotation_reranking.models_data import Candidate
+
+_INSTRUCTION = (
+    "You are matching a metabolite query to the single best knowledge-graph node.\n"
+    "Choose exactly one candidate. Respond with ONLY its CHEBI CURIE (e.g. CHEBI:12345)."
+)
+
+def _serialize(c: Candidate, blind_rm: bool) -> str:
+    equiv = [e for e in c.equivalent_ids if not (blind_rm and e.startswith("RM:"))]
+    return f"- {c.id} | name={c.name} | score={c.score} | equivalent_ids={equiv}"
+
+def build_prompt(candidates: list[Candidate], blind_rm: bool) -> str:
+    lines = "\n".join(_serialize(c, blind_rm) for c in candidates)
+    return f"{_INSTRUCTION}\n\nCandidates:\n{lines}\n\nAnswer with one CURIE:"
+
+def parse_selection(text: str, candidates: list[Candidate]) -> str | None:
+    ids = {c.id for c in candidates}
+    for m in re.findall(r"CHEBI:\d+", text):
+        if m in ids:
+            return m
+    return None
+
+class LlmReranker:
+    def __init__(self, model_name: str, call_fn, blind_rm: bool):
+        self.model_name = model_name
+        self.call_fn = call_fn            # (model_name, prompt) -> str
+        self.blind_rm = blind_rm
+        self.name = f"llm:{model_name}{'/blind' if blind_rm else ''}"
+
+    def select(self, candidates: list[Candidate]) -> str | None:
+        if not candidates:
+            return None
+        text = self.call_fn(self.model_name, build_prompt(candidates, self.blind_rm))
+        return parse_selection(text, candidates)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/studies/annotation_reranking/test_llm.py -v`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add studies/annotation_reranking/rerankers/llm.py tests/studies/annotation_reranking/test_llm.py
+git commit -m "feat(study): LLM reranker with RM-blinding + off-list-safe parsing"
+```
+
+---
+
+### Task 6: Unified model call layer + roster
+
+**Files:**
+- Create: `studies/annotation_reranking/model_call.py`
+- Test: `tests/studies/annotation_reranking/test_model_call.py`
+
+**Interfaces:**
+- Produces:
+  - `ModelCfg(label: str, provider: str, model_id: str, quant_note: str)` dataclass. `provider ∈ {"anthropic", "openai", "openrouter"}`.
+  - `ROSTER: list[ModelCfg]` — the full matrix: Opus, Sonnet (anthropic), a GPT-5.5-class id (openai; pin at run time), Qwen3-4B, Qwen3-8B + comparables (openrouter, `quant_note="OpenRouter fp8, NOT local Q4"`).
+  - `call_model(cfg: ModelCfg, prompt: str, seed: int = 0) -> tuple[str, float, float]` → `(text, cost_usd, latency_s)`, `temperature=0`.
+
+**Note on the billing-leak caveat:** this harness makes **direct single-shot API calls** — it does not spawn `ce:` subagents, so the model-ablation subagent-billing-leak does not apply. Cost is read from each SDK response's usage where available; for OpenRouter, prefer the response's reported cost, else compute from token usage × the pinned per-model price recorded in the manifest.
+
+- [ ] **Step 1: Write the failing test (mock SDK clients)**
+
+```python
+# tests/studies/annotation_reranking/test_model_call.py
+from unittest.mock import patch
+from studies.annotation_reranking import model_call
+from studies.annotation_reranking.model_call import ModelCfg
+
+def test_roster_has_full_matrix_providers():
+    labels = {c.label for c in model_call.ROSTER}
+    assert {"opus", "sonnet"} <= labels
+    assert any(c.provider == "openai" for c in model_call.ROSTER)     # GPT-5.5-class
+    assert any(c.provider == "openrouter" for c in model_call.ROSTER) # small open
+    assert all(c.quant_note for c in model_call.ROSTER if c.provider == "openrouter")
+
+def test_call_model_openrouter_returns_text_cost_latency():
+    cfg = ModelCfg("qwen3-8b", "openrouter", "qwen/qwen3-8b", "OpenRouter fp8, NOT local Q4")
+    fake = {"text": "CHEBI:2", "cost": 0.0004}
+    with patch.object(model_call, "_call_openrouter", return_value=fake):
+        text, cost, latency = model_call.call_model(cfg, "prompt", seed=0)
+    assert text == "CHEBI:2" and cost == 0.0004 and latency >= 0.0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/studies/annotation_reranking/test_model_call.py -v`
+Expected: FAIL (`ModuleNotFoundError`).
+
+- [ ] **Step 3: Implement `model_call.py`**
+
+```python
+# studies/annotation_reranking/model_call.py
+import os, time
+from dataclasses import dataclass
+
+@dataclass
+class ModelCfg:
+    label: str
+    provider: str          # "anthropic" | "openai" | "openrouter"
+    model_id: str
+    quant_note: str = ""
+
+# Frontier ids are pinned at run time (see manifest). Values below are the
+# intended slots; confirm exact ids before a billed run.
+ROSTER: list[ModelCfg] = [
+    ModelCfg("opus",    "anthropic",  "claude-opus-4-8"),
+    ModelCfg("sonnet",  "anthropic",  "claude-sonnet-4-6"),
+    ModelCfg("gpt-5.5", "openai",     "PIN_AT_RUNTIME"),
+    ModelCfg("qwen3-4b","openrouter", "qwen/qwen3-4b", "OpenRouter fp8, NOT local Q4"),
+    ModelCfg("qwen3-8b","openrouter", "qwen/qwen3-8b", "OpenRouter fp8, NOT local Q4"),
+]
+
+def _load_openrouter_key() -> str:
+    # ~/.config/model-ablation/env holds: export OPENROUTER_API_KEY=sk-or-...
+    path = os.path.expanduser("~/.config/model-ablation/env")
+    if os.getenv("OPENROUTER_API_KEY"):
+        return os.environ["OPENROUTER_API_KEY"]
+    with open(path) as fh:
+        for line in fh:
+            if "OPENROUTER_API_KEY" in line:
+                return line.strip().split("=", 1)[1].strip().strip('"')
+    raise RuntimeError("OPENROUTER_API_KEY not found")
+
+def _call_openrouter(model_id: str, prompt: str, seed: int) -> dict:
+    from openai import OpenAI
+    client = OpenAI(base_url="https://openrouter.ai/api/v1", api_key=_load_openrouter_key())
+    resp = client.chat.completions.create(
+        model=model_id, temperature=0, seed=seed,
+        messages=[{"role": "user", "content": prompt}],
+    )
+    text = resp.choices[0].message.content or ""
+    cost = getattr(getattr(resp, "usage", None), "cost", 0.0) or 0.0
+    return {"text": text, "cost": float(cost)}
+
+def _call_anthropic(model_id: str, prompt: str, seed: int) -> dict:
+    from anthropic import Anthropic
+    client = Anthropic()
+    resp = client.messages.create(
+        model=model_id, max_tokens=64, temperature=0,
+        messages=[{"role": "user", "content": prompt}],
+    )
+    return {"text": resp.content[0].text, "cost": 0.0}  # cost computed from usage in manifest
+
+def _call_openai(model_id: str, prompt: str, seed: int) -> dict:
+    from openai import OpenAI
+    client = OpenAI()
+    resp = client.chat.completions.create(
+        model=model_id, temperature=0, seed=seed,
+        messages=[{"role": "user", "content": prompt}],
+    )
+    return {"text": resp.choices[0].message.content or "", "cost": 0.0}
+
+_DISPATCH = {"openrouter": _call_openrouter, "anthropic": _call_anthropic, "openai": _call_openai}
+
+def call_model(cfg: ModelCfg, prompt: str, seed: int = 0) -> tuple[str, float, float]:
+    t0 = time.monotonic()
+    out = _DISPATCH[cfg.provider](cfg.model_id, prompt, seed)
+    return out["text"], float(out.get("cost", 0.0)), time.monotonic() - t0
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/studies/annotation_reranking/test_model_call.py -v`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add studies/annotation_reranking/model_call.py tests/studies/annotation_reranking/test_model_call.py
+git commit -m "feat(study): unified model-call layer + full-matrix roster"
+```
+
+---
+
+### Task 7: Scoring + statistics (per-regime accuracy, Wilson CI, McNemar)
+
+**Files:**
+- Create: `studies/annotation_reranking/scoring.py`
+- Test: `tests/studies/annotation_reranking/test_scoring.py`
+
+**Interfaces:**
+- Consumes: `RerankResult` from Task 1.
+- Produces:
+  - `wilson_ci(k: int, n: int, z: float = 1.96) -> tuple[float, float]`
+  - `accuracy(results: list[RerankResult]) -> tuple[float, tuple[float, float]]` (point + Wilson CI, over results with `is_correct is not None`)
+  - `mcnemar_exact(a_correct: list[bool], b_correct: list[bool]) -> tuple[int, int, float]` → `(b01, b10, p_value)` two-sided exact binomial on discordant pairs.
+  - `min_discordant_for_sig(n_discordant: int, alpha: float = 0.05) -> int` (helper that reports the ≥6-on-n≈13 fact).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/studies/annotation_reranking/test_scoring.py
+import math
+from studies.annotation_reranking.scoring import wilson_ci, mcnemar_exact, min_discordant_for_sig
+
+def test_wilson_ci_bounds_are_ordered_and_in_unit_interval():
+    lo, hi = wilson_ci(1, 13)
+    assert 0.0 <= lo < hi <= 1.0
+
+def test_mcnemar_all_discordant_one_direction_is_significant():
+    a = [True]*6 + [False]*7   # model A correct on 6 where B wrong
+    b = [False]*6 + [False]*7
+    b01, b10, p = mcnemar_exact(a, b)
+    assert b10 == 6 and b01 == 0
+    assert p < 0.05
+
+def test_mcnemar_small_delta_not_significant():
+    a = [True, True, False, False]
+    b = [False, True, True, False]   # 1 vs 1 discordant
+    _, _, p = mcnemar_exact(a, b)
+    assert p > 0.05
+
+def test_min_discordant_threshold_matches_doc_claim():
+    # the "≥6 discordant pairs to clear p<0.05" fact the design doc cites
+    assert min_discordant_for_sig(6) <= 6
+    assert min_discordant_for_sig(4) > 4   # 4 discordant can't reach significance
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/studies/annotation_reranking/test_scoring.py -v`
+Expected: FAIL (`ModuleNotFoundError`).
+
+- [ ] **Step 3: Implement `scoring.py`**
+
+```python
+# studies/annotation_reranking/scoring.py
+import math
+from studies.annotation_reranking.models_data import RerankResult
+
+def wilson_ci(k: int, n: int, z: float = 1.96) -> tuple[float, float]:
+    if n == 0:
+        return (0.0, 1.0)
+    p = k / n
+    denom = 1 + z*z/n
+    center = (p + z*z/(2*n)) / denom
+    half = (z * math.sqrt(p*(1-p)/n + z*z/(4*n*n))) / denom
+    return (max(0.0, center - half), min(1.0, center + half))
+
+def accuracy(results: list[RerankResult]) -> tuple[float, tuple[float, float]]:
+    scored = [r for r in results if r.is_correct is not None]
+    n = len(scored)
+    k = sum(1 for r in scored if r.is_correct)
+    return (k / n if n else 0.0, wilson_ci(k, n))
+
+def _binom_pmf(k: int, n: int, p: float = 0.5) -> float:
+    return math.comb(n, k) * p**k * (1-p)**(n-k)
+
+def mcnemar_exact(a_correct: list[bool], b_correct: list[bool]) -> tuple[int, int, float]:
+    b01 = sum(1 for a, b in zip(a_correct, b_correct) if (not a) and b)
+    b10 = sum(1 for a, b in zip(a_correct, b_correct) if a and (not b))
+    n = b01 + b10
+    if n == 0:
+        return (b01, b10, 1.0)
+    x = min(b01, b10)
+    tail = sum(_binom_pmf(i, n) for i in range(0, x + 1))
+    return (b01, b10, min(1.0, 2 * tail))
+
+def min_discordant_for_sig(n_discordant: int, alpha: float = 0.05) -> int:
+    # smallest all-one-direction discordant count whose two-sided exact p < alpha
+    for m in range(1, n_discordant + 1):
+        if 2 * _binom_pmf(0, m) < alpha:
+            return m
+    return n_discordant + 1
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/studies/annotation_reranking/test_scoring.py -v`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add studies/annotation_reranking/scoring.py tests/studies/annotation_reranking/test_scoring.py
+git commit -m "feat(study): scoring + exact McNemar/Wilson statistics"
+```
+
+---
+
+### Task 8: Orchestrator — full matrix, shadow paths, timestamped output, manifest
+
+**Files:**
+- Create: `studies/annotation_reranking/run.py`
+- Test: `tests/studies/annotation_reranking/test_run.py`
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces:
+  - `build_manifest(csv_path, top_n, seeds, roster, hardware) -> dict` (pure; pins hash/models/seeds/quant/hardware).
+  - `score_case(case, candidates, reranker, model_label) -> RerankResult` (pure; handles empty list, off-list `None`, marks `error`; `is_correct=None` when `label_source=="refmet_agreement"`).
+  - `run_matrix(csv_path, top_n=20, seeds=(0,1,2), out_dir=None) -> str` — iterates cases × rerankers × models × seeds, writes `results.jsonl` + `manifest.json` + `summary.json` to a **timestamped dir by default**, returns the path.
+
+**Shadow-path rules (encode, don't defer):** empty candidate list → `selected_id=None`, `error="empty_candidates"`, `is_correct=False`; off-list/unparseable LLM output → `error="off_list"`, `is_correct=False` (never silently dropped); API exception → caught, `error=str(e)`, `is_correct=False`, run continues; ordering counterbalanced by shuffling candidates per seed with a seeded RNG.
+
+- [ ] **Step 1: Write the failing test (pure pieces, no network)**
+
+```python
+# tests/studies/annotation_reranking/test_run.py
+from studies.annotation_reranking.run import build_manifest, score_case
+from studies.annotation_reranking.rerankers.deterministic import RmAnchorReranker
+from studies.annotation_reranking.models_data import EvalCase, Candidate
+
+def _case(correct, src): return EvalCase("x","MS2","1","r",["CHEBI:2"],"b","cat",correct,src)
+
+def test_manifest_pins_reproducibility_fields():
+    m = build_manifest("SOME.csv", 20, (0,1,2), [], "test-box")
+    for key in ("dataset_sha256", "top_n", "seeds", "temperature", "models", "hardware"):
+        assert key in m
+    assert m["temperature"] == 0
+
+def test_score_case_empty_candidates_marks_error_not_drop():
+    r = score_case(_case("CHEBI:9","independent_refmet_error"), [], RmAnchorReranker(), None)
+    assert r.selected_id is None and r.error == "empty_candidates" and r.is_correct is False
+
+def test_score_case_refmet_agreement_is_unscored():
+    cands = [Candidate("CHEBI:2", 5.0, "n", equivalent_ids=["RM:1"])]
+    r = score_case(_case(None, "refmet_agreement"), cands, RmAnchorReranker(), None)
+    assert r.is_correct is None            # agreement only, never counted as skill
+
+def test_score_case_independent_correct_is_scored():
+    cands = [Candidate("CHEBI:9", 3.0, "n", equivalent_ids=["RM:1"]),
+             Candidate("CHEBI:2", 5.0, "n", equivalent_ids=[])]
+    r = score_case(_case("CHEBI:9","independent_biomapper_error"), cands, RmAnchorReranker(), None)
+    assert r.selected_id == "CHEBI:9" and r.is_correct is True
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/studies/annotation_reranking/test_run.py -v`
+Expected: FAIL (`ModuleNotFoundError`).
+
+- [ ] **Step 3: Implement `run.py`**
+
+```python
+# studies/annotation_reranking/run.py
+import json, os, random, datetime as _dt
+from studies.annotation_reranking.dataset import load_eval_cases, dataset_sha256
+from studies.annotation_reranking.retrieval import fetch_candidates
+from studies.annotation_reranking.regimes import classify_regime
+from studies.annotation_reranking.models_data import RerankResult
+from studies.annotation_reranking.rerankers.base import REGISTRY
+
+def build_manifest(csv_path, top_n, seeds, roster, hardware) -> dict:
+    return {
+        "dataset_sha256": dataset_sha256(csv_path) if os.path.exists(csv_path) else None,
+        "top_n": top_n, "seeds": list(seeds), "temperature": 0,
+        "models": [getattr(c, "model_id", str(c)) for c in roster],
+        "quant_notes": {getattr(c, "label", ""): getattr(c, "quant_note", "") for c in roster},
+        "hardware": hardware,
+    }
+
+def score_case(case, candidates, reranker, model_label) -> RerankResult:
+    regime = classify_regime(candidates)
+    base = dict(case_name=case.name, reranker=reranker.name, model=model_label,
+                correct_id=case.correct_id, label_source=case.label_source, regime=regime,
+                cost_usd=0.0, latency_s=0.0)
+    if not candidates:
+        return RerankResult(selected_id=None, is_correct=False, error="empty_candidates", **base)
+    try:
+        selected = reranker.select(candidates)
+    except Exception as e:  # API/parse failure — record, continue
+        return RerankResult(selected_id=None, is_correct=False, error=str(e), **base)
+    if selected is None:
+        return RerankResult(selected_id=None, is_correct=False, error="off_list", **base)
+    is_correct = None if case.correct_id is None else (selected == case.correct_id)
+    return RerankResult(selected_id=selected, is_correct=is_correct, **base)
+
+def run_matrix(csv_path, top_n=20, seeds=(0, 1, 2), out_dir=None, hardware="unspecified") -> str:
+    stamp = _dt.datetime.now(_dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    out_dir = out_dir or os.path.join(os.path.dirname(__file__), "runs", stamp)
+    os.makedirs(out_dir, exist_ok=True)
+    cases = load_eval_cases(csv_path)
+    with open(os.path.join(out_dir, "manifest.json"), "w") as fh:
+        json.dump(build_manifest(csv_path, top_n, seeds, list(REGISTRY.values()), hardware), fh, indent=2)
+    with open(os.path.join(out_dir, "results.jsonl"), "w") as fh:
+        for case in cases:
+            candidates = fetch_candidates(case.name, "metabolite", top_n=top_n)
+            for seed in seeds:
+                rng = random.Random(seed)
+                shuffled = candidates[:]
+                rng.shuffle(shuffled)                      # position-bias control
+                for reranker in REGISTRY.values():
+                    r = score_case(case, shuffled, reranker, model_label=None)
+                    fh.write(json.dumps(r.__dict__) + "\n")
+    print(f"[run] results saved to {out_dir}")
+    return out_dir
+```
+
+*(LLM rerankers are added to `REGISTRY` by constructing `LlmReranker` per `ModelCfg` and registering them before `run_matrix`; the orchestration loop above is model-agnostic. Wire this in `__main__` / README, Task 9.)*
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/studies/annotation_reranking/test_run.py -v`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add studies/annotation_reranking/run.py tests/studies/annotation_reranking/test_run.py
+git commit -m "feat(study): matrix orchestrator with shadow-path handling + timestamped output"
+```
+
+---
+
+### Task 9: CLI entrypoint, README/reproducibility SOP, full suite green
+
+**Files:**
+- Create: `studies/annotation_reranking/README.md`
+- Modify: `studies/annotation_reranking/run.py` (add `__main__` CLI + LLM registration)
+- Modify: `.gitignore` (add `studies/annotation_reranking/runs/`)
+
+**Interfaces:**
+- Produces: `python -m studies.annotation_reranking.run --top-n 20 --seeds 0,1,2 [--out DIR] [--models sonnet,qwen3-8b]` — registers deterministic + selected LLM rerankers, runs the matrix, prints the saved path.
+
+- [ ] **Step 1: Add `__main__` CLI + LLM registration to `run.py`**
+
+```python
+# append to studies/annotation_reranking/run.py
+def _register_llms(model_labels: list[str], blind: bool = True) -> None:
+    from studies.annotation_reranking.model_call import ROSTER, call_model
+    from studies.annotation_reranking.rerankers.base import register
+    from studies.annotation_reranking.rerankers.llm import LlmReranker
+    by_label = {c.label: c for c in ROSTER}
+    for label in model_labels:
+        cfg = by_label[label]
+        call_fn = lambda m, p, _cfg=cfg: call_model(_cfg, p)[0]
+        register(LlmReranker(cfg.label, call_fn=call_fn, blind_rm=blind))
+        register(LlmReranker(cfg.label, call_fn=call_fn, blind_rm=False))
+
+if __name__ == "__main__":
+    import argparse
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--csv", default="/home/trentleslie/Documents/Trent's Vault/Active 🎯/Work/Projects/biomapper2 - refmet ChEBI analysis/chebi_disagreements_cat.csv")
+    ap.add_argument("--top-n", type=int, default=20)
+    ap.add_argument("--seeds", default="0,1,2")
+    ap.add_argument("--models", default="")   # comma list of roster labels; empty = deterministic only
+    ap.add_argument("--out", default=None)
+    ap.add_argument("--hardware", default="unspecified")
+    a = ap.parse_args()
+    if a.models:
+        _register_llms([x for x in a.models.split(",") if x])
+    path = run_matrix(a.csv, a.top_n, tuple(int(s) for s in a.seeds.split(",")), a.out, a.hardware)
+    print(path)
+```
+
+- [ ] **Step 2: Write `README.md`**
+
+Include: purpose (one paragraph), the **Phase 0 gate first** instruction, exact run commands (deterministic-only vs. full matrix), where results land (timestamped `runs/<UTC>/` by default), what `manifest.json` pins, and the two caveats that must appear in any writeup: **(1)** without the ≥100-pair curated set the skill-revealing independent subset is ~2 cases (rm_anchor is right-by-construction on the 11 BioMapper-error cases); **(2)** OpenRouter serves open models at fp8, not local Q4 — the local-vs-large *hardware* claim needs a true-Q4 run.
+
+- [ ] **Step 3: Ignore run artifacts**
+
+Add `studies/annotation_reranking/runs/` to `.gitignore`.
+
+- [ ] **Step 4: Run the whole suite**
+
+Run: `uv run pytest tests/studies/annotation_reranking/ -v -m "not external"`
+Expected: PASS (all unit tests across Tasks 1–8).
+
+- [ ] **Step 5: Deterministic-only smoke run (no model spend, needs Kestrel)**
+
+Run: `uv run python -m studies.annotation_reranking.run --top-n 20 --seeds 0`
+Expected: prints a `runs/<UTC>/` path; `results.jsonl` contains top1 + rm_anchor rows for 172 cases; `manifest.json` has a real `dataset_sha256`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add studies/annotation_reranking/README.md studies/annotation_reranking/run.py .gitignore
+git commit -m "feat(study): CLI entrypoint, reproducibility README, gitignore run artifacts"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (design doc → task):**
+- Retrieve top-N candidates (score/name/synonyms/prefixes/equivalent_ids) → Task 2. ✓
+- rm_anchor + top-1 baseline → Task 4. ✓
+- LLM rerankers (Anthropic/OpenAI/OpenRouter small) → Tasks 5–6. ✓
+- **Circularity #1** (don't headline accuracy-vs-RefMet) → `label_source` split; `refmet_agreement` rows carry `is_correct=None` (Task 1, 8). ✓
+- **Circularity #2** (independent-label provenance) → the n=2 partition is computed and surfaced; `README` mandates the caveat (Tasks 1, 3, 9). ✓
+- **RM: leakage** → RM-blinded condition (Task 5), both conditions registered (Task 9). ✓
+- **Statistical validity** → Wilson CI + exact McNemar + `min_discordant_for_sig` (Task 7). ✓
+- **Phase 0 regime measurement before model spend** → Task 3 (explicit decision gate). ✓
+- **Confounds** (ordering/seed/temperature) → seeded shuffle + temperature=0 (Tasks 6, 8). ✓
+- **Shadow paths** (empty/off-list/API failure/tie) → Tasks 4, 8. ✓
+- **Reproducibility SOP** (timestamped-by-default, pinned manifest) → Tasks 8–9. ✓
+- **Q4-quant caveat / hardware** → `quant_note` in roster + README caveat (Tasks 6, 9). ✓
+
+**Deferred to run-time decisions (not code — flagged in the design doc's Open Questions, not gaps here):** exact GPT-5.5 id (`PIN_AT_RUNTIME`); whether to fund the ≥100-pair curated set (the harness runs on whatever labeled cases exist); local-hosting box for the true-Q4 timing (the fp8 OpenRouter numbers are collected regardless).
+
+**Placeholder scan:** the only intentional literal placeholder is `PIN_AT_RUNTIME` for the GPT-5.5 id and `<AnnotatorClass>`/`<get_equivalent_ids>` in Task 2, each resolved by an explicit confirm-symbol step. No "TODO/handle edge cases" left in logic.
+
+**Type consistency:** `Candidate`, `EvalCase`, `RerankResult` defined once in `models_data.py`; `select()` returns `str | None` everywhere; `call_model` returns `(text, cost, latency)` consistently; `Reranker.name` used as the results key throughout.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ select = [
 known-first-party = ["biomapper2"]
 
 [tool.pytest.ini_options]
+pythonpath = ["."]
 markers = [
     "integration: marks tests as integration tests (deselect with '-m \"not integration\"')",
     "external: tests that depend on third-party APIs we don't control",

--- a/studies/annotation_reranking/README.md
+++ b/studies/annotation_reranking/README.md
@@ -108,18 +108,22 @@ is written first.
    retired as a performance baseline.  `source_weight_guard` is the correct
    reference point.
 
-2. **Independent labels — current reality vs. planned scope.**
-   Currently `dataset.py` derives independent labels from the ~13 hand-triaged
-   cases only (`TRUE_BIOMAPPER_ERRORS` / `REFMET_ERRORS`).  All other 159 cases
-   receive `label_source="refmet_agreement"` and are **unscored** (`is_correct=None`).
-   InChIKey first-block connectivity (KG → MW → PubChem) is the *intended*
-   non-circular label source that would scale past the 13, but the label-derivation
-   pass is **NOT YET IMPLEMENTED** — it is a planned follow-up.
-   `EvalCase.inchikey_block_correct` and `EvalCase.retrievable` are reserved fields
-   for that future pass; they are never populated by the current code.
-   Once that pass lands, stereo/protonation cases (same connectivity, different
-   structure) would be assigned `expert_needed` and excluded from the scoreable
-   subset.  Until then, accuracy figures cover only the 13 hand-triaged cases.
+2. **Independent labels — two sources.**
+   The ~13 hand-triaged cases (`TRUE_BIOMAPPER_ERRORS` / `REFMET_ERRORS`) are
+   expert-adjudicated and always take precedence.  Beyond them, `labels.py`
+   derives independent labels from **InChIKey first-block (2-D connectivity)** —
+   a non-circular structural signal — via `derive_labels(cases)`, enabled at
+   run time with the `--derive-labels` flag (or `run_matrix(..., derive_labels=True)`).
+   For each disagreement it resolves the analyte's true connectivity by name
+   (Metabolomics Workbench → PubChem) and each competing node's connectivity
+   (KG → MW → PubChem), then: if the RefMet and BioMapper nodes share a block
+   (stereo/charge/protonation — same molecule) the case is `expert_needed` and
+   **excluded from the scoreable subset**; otherwise the node matching the
+   analyte's connectivity becomes the `inchikey_connectivity` label.  Ambiguous
+   or unresolvable cases stay `refmet_agreement` (unscored, `is_correct=None`).
+   Label derivation requires live MW/PubChem calls and is a gate-time step, not
+   part of CI; without `--derive-labels`, only the ~13 hand-triaged cases are scored.
+   `EvalCase.inchikey_block_correct` records the derived connectivity block.
 
 3. **`majority = top-score` proxy.**  This study has no multi-annotator vote
    as in production's resolver.  `source_weight_guard` uses the highest-scoring

--- a/studies/annotation_reranking/README.md
+++ b/studies/annotation_reranking/README.md
@@ -108,11 +108,18 @@ is written first.
    retired as a performance baseline.  `source_weight_guard` is the correct
    reference point.
 
-2. **Independent labels = InChIKey first-block connectivity
-   (KG → MW → PubChem); they CANNOT adjudicate stereoisomers or
-   protonation/charge-state variants** (same first block, different structure).
-   Those cases are assigned `expert_needed` and excluded from the scoreable
-   subset.  Accuracy figures are conditioned on this exclusion.
+2. **Independent labels — current reality vs. planned scope.**
+   Currently `dataset.py` derives independent labels from the ~13 hand-triaged
+   cases only (`TRUE_BIOMAPPER_ERRORS` / `REFMET_ERRORS`).  All other 159 cases
+   receive `label_source="refmet_agreement"` and are **unscored** (`is_correct=None`).
+   InChIKey first-block connectivity (KG → MW → PubChem) is the *intended*
+   non-circular label source that would scale past the 13, but the label-derivation
+   pass is **NOT YET IMPLEMENTED** — it is a planned follow-up.
+   `EvalCase.inchikey_block_correct` and `EvalCase.retrievable` are reserved fields
+   for that future pass; they are never populated by the current code.
+   Once that pass lands, stereo/protonation cases (same connectivity, different
+   structure) would be assigned `expert_needed` and excluded from the scoreable
+   subset.  Until then, accuracy figures cover only the 13 hand-triaged cases.
 
 3. **`majority = top-score` proxy.**  This study has no multi-annotator vote
    as in production's resolver.  `source_weight_guard` uses the highest-scoring

--- a/studies/annotation_reranking/README.md
+++ b/studies/annotation_reranking/README.md
@@ -1,0 +1,163 @@
+# Annotation-Reranking Study
+
+## Purpose
+
+This study evaluates whether LLM rerankers (Anthropic, OpenAI, OpenRouter) improve
+ChEBI candidate selection over deterministic baselines on the 172-case ChEBI
+disagreement dataset.  The primary question is whether a prompted LLM — given
+Kestrel hybrid-search results plus candidate metadata — can outperform the
+`source_weight_guard` rule, which selects the RefMet-anchor candidate unless
+InChIKey connectivity says it is the same molecule as the resolver's top hit.
+
+Results are written by default to a timestamped `runs/<UTC-timestamp>/` directory
+so that every run is self-contained and reproducible without overwriting prior runs.
+
+---
+
+## Run Phase 0 Gate FIRST
+
+Before spending any LLM budget, run the Phase 0 regime measurement to understand
+the retrieval ceiling and the independent label partition:
+
+```bash
+uv run python -m studies.annotation_reranking.phase0
+```
+
+Phase 0 reports:
+
+- How many of the 172 cases have a correct answer present in the top-N candidates
+  (retrieval ceiling — reranking cannot fix un-retrieved answers).
+- The independent vs. refmet_agreement label split (the LLM can only be fairly
+  evaluated on the independent partition).
+
+**Stop and review Phase 0 numbers before proceeding.**  If the independent
+partition is too small to detect a meaningful signal (< 50 cases), collecting
+more curated labels is a prerequisite, not a post-hoc note.
+
+---
+
+## Run Commands
+
+### Deterministic only (no API calls, no model spend)
+
+```bash
+uv run python -m studies.annotation_reranking.run \
+    --csv "/path/to/chebi_disagreements_cat.csv" \
+    --top-n 20 \
+    --seeds 0,1,2
+```
+
+Omit `--models` (or leave it empty) to run only the three deterministic rerankers:
+`top1`, `rm_anchor`, and `source_weight_guard`.  This is the default.
+
+The default `--csv` path points to the Global-Constraints vault CSV on the local
+machine.  Pass an explicit path when running on a different host.
+
+### Full matrix (deterministic + LLM rerankers)
+
+```bash
+# Prerequisite: pin the gpt-5.5 model_id in model_call.py (replace PIN_AT_RUNTIME)
+# Prerequisite: add openai and anthropic to project dependencies
+
+uv run python -m studies.annotation_reranking.run \
+    --csv "/path/to/chebi_disagreements_cat.csv" \
+    --top-n 20 \
+    --seeds 0,1,2 \
+    --models sonnet,qwen3-8b \
+    --hardware "A100-40G" \
+    --out runs/2026-07-08-full
+```
+
+`--models` is a comma-separated list of labels from the ROSTER defined in
+`model_call.py` (e.g. `opus`, `sonnet`, `gpt-5.5`, `qwen3-4b`, `qwen3-8b`).
+Each label registers both a blind reranker (`llm:<label>/blind`, RM: ids stripped)
+and a non-blind reranker (`llm:<label>`).
+
+### Output location
+
+Results land in `studies/annotation_reranking/runs/<UTC-timestamp>/` by default.
+The printed path on stdout is the directory that was written.
+
+---
+
+## What `manifest.json` Pins
+
+Every run writes `manifest.json` before `results.jsonl`.  It records:
+
+| Field | Description |
+|---|---|
+| `dataset_sha256` | SHA-256 of the input CSV for bit-exact dataset identification |
+| `top_n` | Candidate window size passed to Kestrel |
+| `seeds` | RNG seeds used for candidate position shuffles |
+| `temperature` | Always 0 (deterministic LLM calls) |
+| `models` | Model IDs for all LLM rerankers in the run |
+| `quant_notes` | Per-model quantization notes (e.g. fp8 vs. Q4) |
+| `hardware` | Free-form hardware descriptor for the run host |
+
+A partial run (interrupted mid-results) is still inspectable because the manifest
+is written first.
+
+---
+
+## Mandatory Caveats (Must Appear in Any Writeup)
+
+1. **Baseline is `source_weight_guard`, not `rm_anchor`.**
+   `rm_anchor` is kept in the registry to demonstrate circularity: it is
+   right-by-construction on the 11 BioMapper-error cases because it picks the
+   RefMet anchor, which is the ground-truth label for those cases.  It is
+   retired as a performance baseline.  `source_weight_guard` is the correct
+   reference point.
+
+2. **Independent labels = InChIKey first-block connectivity
+   (KG → MW → PubChem); they CANNOT adjudicate stereoisomers or
+   protonation/charge-state variants** (same first block, different structure).
+   Those cases are assigned `expert_needed` and excluded from the scoreable
+   subset.  Accuracy figures are conditioned on this exclusion.
+
+3. **`majority = top-score` proxy.**  This study has no multi-annotator vote
+   as in production's resolver.  `source_weight_guard` uses the highest-scoring
+   Kestrel candidate as a proxy for the majority vote.  Results may not
+   generalise to the full resolver ensemble.
+
+4. **Retrieval ceiling: ~45 / 172 correct nodes absent at top-N ≥ 200.**
+   Accuracy is reported conditioned on retrievability.  Reranking cannot reach
+   answers that are not in the candidate set.
+
+5. **RM-blinding strips only the `RM:` ids from `equivalent_ids`.**
+   Candidate names are retained (legitimate signal from the KG node, not a
+   RefMet-specific field).  Residual name-similarity between a candidate name
+   and the query is an inherent, un-blindable limitation of any name-based
+   reranker.  This is documented here, not stripped.
+
+6. **OpenRouter serves open models at fp8, NOT local Q4.**
+   The `qwen3-4b` and `qwen3-8b` numbers collected via OpenRouter reflect
+   cloud fp8 inference.  Any hardware-cost claim comparing "small local model
+   vs. large cloud model" requires a true-Q4 run on the target box.  The
+   `quant_notes` field in `manifest.json` carries this caveat per model.
+
+7. **RUN prerequisites.**
+   Before any billed run: (a) pin the exact GPT-5.5-class `model_id` in
+   `model_call.py` (replace `PIN_AT_RUNTIME`); (b) add `openai` and `anthropic`
+   to project dependencies (`uv add openai anthropic`).
+
+---
+
+## Directory Layout
+
+```
+studies/annotation_reranking/
+├── README.md          ← this file
+├── dataset.py         ← load_eval_cases, dataset_sha256
+├── inchikey_resolver.py  ← connectivity_match (InChIKey first-block)
+├── model_call.py      ← ROSTER, call_model (lazy API dispatch)
+├── models_data.py     ← Candidate, EvalCase, RerankResult dataclasses
+├── phase0.py          ← Phase 0 regime measurement (run first)
+├── regimes.py         ← classify_regime
+├── retrieval.py       ← fetch_candidates (Kestrel hybrid search)
+├── run.py             ← run_matrix, score_case, _register_llms, CLI
+├── scoring.py         ← Wilson CI, McNemar, min_discordant_for_sig
+└── rerankers/
+    ├── base.py        ← Reranker protocol, REGISTRY, register
+    ├── deterministic.py  ← Top1Reranker, RmAnchorReranker, SourceWeightGuardReranker
+    └── llm.py         ← build_prompt, parse_selection, LlmReranker
+```

--- a/studies/annotation_reranking/dataset.py
+++ b/studies/annotation_reranking/dataset.py
@@ -1,0 +1,77 @@
+import csv
+import hashlib
+
+from studies.annotation_reranking.models_data import EvalCase
+
+# Exact names copied from analyze.py TRUE_BIOMAPPER_ERRORS dict (11 cases).
+# BioMapper picked the wrong compound in each of these; the correct answer
+# is RefMet's node (CHEBI:<refmet_id>).
+TRUE_BIOMAPPER_ERRORS: set[str] = {
+    "(15:3)-anacardic acid",
+    "2-hydroxypalmitate",
+    "4-acetamidophenol",
+    "4-hydroxyhippurate",
+    "4-methylbenzenesulfonate",
+    "9-hydroxystearate",
+    "5_HpEPE__4_55",
+    "2-Methylmaleate",
+    "laurylcarnitine (C12)",
+    "myristoylcarnitine (C14)",
+    "glycerophosphoinositol*",
+}
+
+# Exact names copied from analyze.py REFMET_ERRORS dict (2 cases).
+# RefMet was wrong; BioMapper's first ID is the correct answer.
+REFMET_ERRORS: set[str] = {
+    "6-shogaol",
+    "Diethyl 2-methyl-3-oxosuccinate",
+}
+
+
+def _curie(raw: str) -> str:
+    """Normalize a bare ChEBI integer or existing CURIE to 'CHEBI:<n>' form."""
+    raw = raw.strip()
+    return raw if raw.startswith("CHEBI:") else f"CHEBI:{raw}"
+
+
+def load_eval_cases(csv_path: str) -> list[EvalCase]:
+    """Load all rows from the ChEBI disagreement CSV as typed EvalCase objects."""
+    cases: list[EvalCase] = []
+    with open(csv_path, newline="", encoding="utf-8") as fh:
+        for row in csv.DictReader(fh):
+            name = row["name"]
+            bm_ids = [_curie(x) for x in row["biomapper_id"].split("|") if x.strip()]
+            if name in TRUE_BIOMAPPER_ERRORS:
+                correct: str | None = _curie(row["refmet_id"])
+                src = "independent_biomapper_error"
+            elif name in REFMET_ERRORS:
+                correct = bm_ids[0] if bm_ids else None
+                src = "independent_refmet_error"
+            else:
+                correct = None
+                src = "refmet_agreement"
+            cases.append(
+                EvalCase(
+                    name=name,
+                    level=row["level"],
+                    refmet_id=row["refmet_id"],
+                    refmet_name=row["refmet_name"],
+                    biomapper_ids=bm_ids,
+                    biomapper_name=row["biomapper_name"],
+                    category=row["category"],
+                    correct_id=correct,
+                    label_source=src,
+                )
+            )
+    return cases
+
+
+def independent_cases(cases: list[EvalCase]) -> list[EvalCase]:
+    """Return only the independently-adjudicated cases (label_source starts with 'independent_')."""
+    return [c for c in cases if c.label_source.startswith("independent_")]
+
+
+def dataset_sha256(csv_path: str) -> str:
+    """Return the SHA-256 hex digest of the CSV file for reproducibility pinning."""
+    with open(csv_path, "rb") as fh:
+        return hashlib.sha256(fh.read()).hexdigest()

--- a/studies/annotation_reranking/inchikey_resolver.py
+++ b/studies/annotation_reranking/inchikey_resolver.py
@@ -99,13 +99,11 @@ def _block_from_pubchem(name: str) -> str | None:
 # ---------------------------------------------------------------------------
 
 
-@functools.lru_cache(maxsize=2048)
-def inchikey_block(node_id: str, name: str) -> str | None:
+def _inchikey_block_impl(node_id: str, name: str) -> str | None:
     """Resolve a node's InChIKey first block (2-D connectivity skeleton).
 
     Tries layers in order: KG → Metabolomics Workbench → PubChem.
     Returns the first non-None result, or None if all layers miss.
-    Result is cached by (node_id, name).
 
     Args:
         node_id: KG CURIE (e.g. "CHEBI:15365")
@@ -125,28 +123,9 @@ def inchikey_block(node_id: str, name: str) -> str | None:
     return _block_from_pubchem(name)
 
 
-# Expose the unwrapped function for tests that need to bypass the LRU cache
-inchikey_block.__wrapped__ = inchikey_block.__wrapped__ if hasattr(inchikey_block, "__wrapped__") else None  # type: ignore[attr-defined]
-
-
-def _make_unwrapped():
-    """Return a non-cached version of inchikey_block for test patching."""
-
-    def _unwrapped(node_id: str, name: str) -> str | None:
-        block = _block_from_kg(node_id)
-        if block is not None:
-            return block
-        block = _block_from_mw(name)
-        if block is not None:
-            return block
-        return _block_from_pubchem(name)
-
-    return _unwrapped
-
-
-# Attach a stable __wrapped__ attribute so tests can call inchikey_block.__wrapped__(...)
-# without hitting the LRU cache — lets them patch the private helpers cleanly.
-inchikey_block.__wrapped__ = _make_unwrapped()  # type: ignore[attr-defined]
+# Result is cached by (node_id, name). functools sets __wrapped__ to _inchikey_block_impl
+# automatically, so tests calling inchikey_block.__wrapped__(...) exercise the real body.
+inchikey_block = functools.lru_cache(maxsize=2048)(_inchikey_block_impl)
 
 
 def connectivity_match(id_a: str, name_a: str, id_b: str, name_b: str) -> bool | None:

--- a/studies/annotation_reranking/inchikey_resolver.py
+++ b/studies/annotation_reranking/inchikey_resolver.py
@@ -1,0 +1,169 @@
+"""InChIKey first-block (2-D connectivity) resolver for the annotation-reranking study.
+
+Provides a layered, cached resolver that returns a metabolite node's InChIKey first block
+(the 14-character connectivity skeleton before the first '-'), used:
+  1. As a non-circular structural label source (independent of RM: annotations).
+  2. As the connectivity signal for the source_weight_guard reranker (Task 4).
+
+Layer order: KG → Metabolomics Workbench → PubChem (first non-None wins).
+Every layer is timeout-guarded and returns None on any error — never raises.
+
+# CONSOLIDATE: replace with core.resolver._connectivity_match once Phase 1b merges
+"""
+
+import functools
+import logging
+
+import requests
+
+from biomapper2.core.linker import Linker
+
+logger = logging.getLogger(__name__)
+
+_REQUEST_TIMEOUT = 10  # seconds
+
+
+# ---------------------------------------------------------------------------
+# Private layer helpers — each is a patchable seam for unit tests
+# ---------------------------------------------------------------------------
+
+
+def _block_from_kg(node_id: str) -> str | None:
+    """Layer 1: resolve via KG equivalent_ids (INCHIKEY prefix).
+
+    Calls Linker.get_equivalent_ids([node_id], prefixes=["INCHIKEY"]) and returns
+    the first block of the first INCHIKEY local_id found, or None on any failure.
+    """
+    try:
+        result = Linker.get_equivalent_ids([node_id], prefixes=["INCHIKEY"])
+        node_map = result.get(node_id, {})
+        ik_ids = node_map.get("INCHIKEY", [])
+        if not ik_ids:
+            return None
+        first_id = ik_ids[0]
+        return first_id.split("-")[0] or None
+    except Exception:
+        logger.debug("_block_from_kg: error resolving %s", node_id, exc_info=True)
+        return None
+
+
+def _block_from_mw(name: str) -> str | None:
+    """Layer 2: resolve via Metabolomics Workbench REST API.
+
+    GET https://www.metabolomicsworkbench.org/rest/refmet/name/{name}/inchi_key
+    Response body is the plain-text InChIKey.
+    """
+    try:
+        url = f"https://www.metabolomicsworkbench.org/rest/refmet/name/{requests.utils.quote(name)}/inchi_key"
+        resp = requests.get(url, timeout=_REQUEST_TIMEOUT)
+        if resp.status_code != 200:
+            return None
+        body = resp.text.strip()
+        if not body or "-" not in body:
+            return None
+        return body.split("-")[0] or None
+    except Exception:
+        logger.debug("_block_from_mw: error resolving %s", name, exc_info=True)
+        return None
+
+
+def _block_from_pubchem(name: str) -> str | None:
+    """Layer 3: resolve via PubChem PUG REST API.
+
+    GET https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/name/{name}/property/InChIKey/JSON
+    Parses PropertyTable.Properties[0].InChIKey.
+    """
+    try:
+        url = (
+            f"https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/name/"
+            f"{requests.utils.quote(name)}/property/InChIKey/JSON"
+        )
+        resp = requests.get(url, timeout=_REQUEST_TIMEOUT)
+        if resp.status_code != 200:
+            return None
+        data = resp.json()
+        props = data.get("PropertyTable", {}).get("Properties", [])
+        if not props:
+            return None
+        ik = props[0].get("InChIKey", "")
+        if not ik or "-" not in ik:
+            return None
+        return ik.split("-")[0] or None
+    except Exception:
+        logger.debug("_block_from_pubchem: error resolving %s", name, exc_info=True)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Public interface
+# ---------------------------------------------------------------------------
+
+
+@functools.lru_cache(maxsize=2048)
+def inchikey_block(node_id: str, name: str) -> str | None:
+    """Resolve a node's InChIKey first block (2-D connectivity skeleton).
+
+    Tries layers in order: KG → Metabolomics Workbench → PubChem.
+    Returns the first non-None result, or None if all layers miss.
+    Result is cached by (node_id, name).
+
+    Args:
+        node_id: KG CURIE (e.g. "CHEBI:15365")
+        name: Human-readable metabolite name used for MW/PubChem fallback lookups.
+
+    Returns:
+        14-character InChIKey first block, or None if unresolvable.
+    """
+    block = _block_from_kg(node_id)
+    if block is not None:
+        return block
+
+    block = _block_from_mw(name)
+    if block is not None:
+        return block
+
+    return _block_from_pubchem(name)
+
+
+# Expose the unwrapped function for tests that need to bypass the LRU cache
+inchikey_block.__wrapped__ = inchikey_block.__wrapped__ if hasattr(inchikey_block, "__wrapped__") else None  # type: ignore[attr-defined]
+
+
+def _make_unwrapped():
+    """Return a non-cached version of inchikey_block for test patching."""
+
+    def _unwrapped(node_id: str, name: str) -> str | None:
+        block = _block_from_kg(node_id)
+        if block is not None:
+            return block
+        block = _block_from_mw(name)
+        if block is not None:
+            return block
+        return _block_from_pubchem(name)
+
+    return _unwrapped
+
+
+# Attach a stable __wrapped__ attribute so tests can call inchikey_block.__wrapped__(...)
+# without hitting the LRU cache — lets them patch the private helpers cleanly.
+inchikey_block.__wrapped__ = _make_unwrapped()  # type: ignore[attr-defined]
+
+
+def connectivity_match(id_a: str, name_a: str, id_b: str, name_b: str) -> bool | None:
+    """Compare 2-D connectivity between two metabolite nodes.
+
+    Returns:
+        True  — both blocks resolved and are identical (same 2-D skeleton).
+        False — both blocks resolved and differ.
+        None  — at least one block could not be resolved.
+
+    Note: stereoisomers and protonation states share the same first block and are
+    considered matching here; positional/constitutional isomers differ and return False.
+
+    # CONSOLIDATE: replace with core.resolver._connectivity_match once Phase 1b merges
+    """
+    block_a = inchikey_block(id_a, name_a)
+    block_b = inchikey_block(id_b, name_b)
+    if block_a is None or block_b is None:
+        return None
+    return block_a == block_b

--- a/studies/annotation_reranking/labels.py
+++ b/studies/annotation_reranking/labels.py
@@ -1,0 +1,154 @@
+"""InChIKey-connectivity label derivation for the annotation-reranking study (Task 10).
+
+Realizes Change B: derives independent structural labels for disagreement cases
+by comparing InChIKey first blocks (2-D connectivity skeletons), scaling the
+eval beyond the ~13 hand-triaged cases.
+
+Public interface
+----------------
+name_block(name) -> str | None
+    The analyte's TRUE InChIKey first block resolved by NAME only
+    (MW → PubChem; no KG layer — there is no node_id for a bare name).
+    Cached by name. Never raises.
+
+derive_label(case, *, name_block_fn, node_block_fn) -> tuple[str|None, str, str|None]
+    Single-case label derivation.  Both block functions are injectable for tests.
+
+derive_labels(cases) -> list[EvalCase]
+    Apply derive_label to every case in-place and return the list.
+"""
+from __future__ import annotations
+
+import functools
+import logging
+from typing import Callable
+
+from studies.annotation_reranking.inchikey_resolver import (
+    _block_from_mw,
+    _block_from_pubchem,
+    inchikey_block,
+)
+from studies.annotation_reranking.models_data import EvalCase
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# name_block — NAME-only resolution (MW → PubChem; no KG layer)
+# ---------------------------------------------------------------------------
+
+def _name_block_impl(name: str) -> str | None:
+    """Resolve the analyte's true InChIKey first block by name.
+
+    Layer order: Metabolomics Workbench → PubChem (no KG — there is no node_id).
+    Returns the first non-None result or None on any error.  Never raises.
+    """
+    block = _block_from_mw(name)
+    if block is not None:
+        return block
+    return _block_from_pubchem(name)
+
+
+# Cached by name — same pattern as inchikey_block.
+name_block: Callable[[str], str | None] = functools.lru_cache(maxsize=2048)(_name_block_impl)
+
+
+# ---------------------------------------------------------------------------
+# derive_label — priority-ordered decision rule
+# ---------------------------------------------------------------------------
+
+def derive_label(
+    case: EvalCase,
+    *,
+    name_block_fn: Callable[[str], str | None] = name_block,
+    node_block_fn: Callable[[str, str], str | None] | None = None,
+) -> tuple[str | None, str, str | None]:
+    """Derive a structural label for *case*.
+
+    Decision rule (PRIORITY ORDER — earlier rules take precedence):
+
+    1. Hand-triaged wins: ``label_source`` starts with ``"independent_"``
+       → return (case.correct_id, case.label_source, None) unchanged.
+
+    2. Same connectivity → not adjudicable: if ``rb is not None`` and any
+       biomapper block ``bb == rb`` → (None, "expert_needed", ref).
+       NOTE: this rule fires even when ref differs from rb.
+
+    3. Structural pick (needs ref):
+       - rb == ref and no bio bb == ref → (refmet_curie, "inchikey_connectivity", ref)
+       - exactly one bio bb == ref and rb != ref → (that_bid, "inchikey_connectivity", ref)
+       - else → (None, "refmet_agreement", ref)
+
+    4. ref is None (and not same-connectivity) → (None, "refmet_agreement", None).
+
+    Parameters
+    ----------
+    case:
+        EvalCase to derive label for.
+    name_block_fn:
+        Injectable function ``(name: str) -> str | None``.  Defaults to
+        ``name_block`` (the module-level cached resolver).
+    node_block_fn:
+        Injectable function ``(node_id: str, name: str) -> str | None``.
+        Defaults to ``inchikey_resolver.inchikey_block``.
+
+    Returns
+    -------
+    tuple of (correct_id, label_source, inchikey_block_correct)
+    """
+    if node_block_fn is None:
+        node_block_fn = inchikey_block
+
+    # Rule 1: hand-triaged cases are returned unchanged.
+    if case.label_source.startswith("independent_"):
+        return (case.correct_id, case.label_source, None)
+
+    refmet_curie = f"CHEBI:{case.refmet_id.strip()}"
+    rb = node_block_fn(refmet_curie, case.refmet_name)
+
+    bio_blocks: list[str | None] = [
+        node_block_fn(bid, case.biomapper_name) for bid in case.biomapper_ids
+    ]
+
+    # Rule 2: same connectivity → not adjudicable (even if ref differs).
+    if rb is not None and any(bb == rb for bb in bio_blocks if bb is not None):
+        ref = name_block_fn(case.name)
+        return (None, "expert_needed", ref)
+
+    # Resolve analyte's true connectivity by name.
+    ref = name_block_fn(case.name)
+
+    # Rule 3: structural pick (ref required).
+    if ref is not None:
+        bio_matches = [
+            bid
+            for bid, bb in zip(case.biomapper_ids, bio_blocks)
+            if bb is not None and bb == ref
+        ]
+        if rb == ref and not bio_matches:
+            return (refmet_curie, "inchikey_connectivity", ref)
+        if len(bio_matches) == 1 and rb != ref:
+            return (bio_matches[0], "inchikey_connectivity", ref)
+        # Ambiguous / neither cleanly matches.
+        return (None, "refmet_agreement", ref)
+
+    # Rule 4: ref is None and not same-connectivity.
+    return (None, "refmet_agreement", None)
+
+
+# ---------------------------------------------------------------------------
+# derive_labels — bulk application
+# ---------------------------------------------------------------------------
+
+def derive_labels(cases: list[EvalCase]) -> list[EvalCase]:
+    """Apply ``derive_label`` to each case and mutate it in-place.
+
+    Sets ``case.correct_id``, ``case.label_source``, and
+    ``case.inchikey_block_correct`` on every case, then returns the list.
+    """
+    for case in cases:
+        correct_id, label_source, inchikey_block_correct = derive_label(case)
+        case.correct_id = correct_id
+        case.label_source = label_source
+        case.inchikey_block_correct = inchikey_block_correct
+    return cases

--- a/studies/annotation_reranking/model_call.py
+++ b/studies/annotation_reranking/model_call.py
@@ -1,0 +1,158 @@
+"""Unified model-call layer + full-matrix roster for the annotation-reranking harness.
+
+Design notes
+------------
+* Direct single-shot API calls — no ce: subagents are spawned here, so the
+  subagent-billing-leak documented in the old ablation harness does NOT apply.
+  Cost is read from each SDK response's usage where available; for OpenRouter,
+  we prefer the response's reported cost, else fall back to 0.0.
+
+* OPENROUTER_API_KEY is read lazily from ~/.config/model-ablation/env (format:
+  export OPENROUTER_API_KEY=...) if not already in the environment.  The read
+  happens inside _load_openrouter_key() which is only called at call time, so
+  importing this module does NOT touch the key file or open any network connections.
+
+* Frontier model ids are pinned at run time.  ``PIN_AT_RUNTIME`` is a sentinel
+  that must be replaced before billed runs.
+"""
+from __future__ import annotations
+
+import os
+import time
+from dataclasses import dataclass, field
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ModelCfg:
+    label: str
+    provider: str       # "anthropic" | "openai" | "openrouter"
+    model_id: str
+    quant_note: str = field(default="")
+
+
+# ---------------------------------------------------------------------------
+# Roster — full matrix
+# ---------------------------------------------------------------------------
+
+ROSTER: list[ModelCfg] = [
+    ModelCfg("opus",     "anthropic",  "claude-opus-4-8"),
+    ModelCfg("sonnet",   "anthropic",  "claude-sonnet-4-6"),
+    # GPT-5.5-class slot; pin the exact id before a billed run
+    ModelCfg("gpt-5.5",  "openai",     "PIN_AT_RUNTIME"),
+    ModelCfg("qwen3-4b", "openrouter", "qwen/qwen3-4b",
+             "OpenRouter fp8, NOT local Q4"),
+    ModelCfg("qwen3-8b", "openrouter", "qwen/qwen3-8b",
+             "OpenRouter fp8, NOT local Q4"),
+]
+
+
+# ---------------------------------------------------------------------------
+# Key loading (lazy — never runs at import time)
+# ---------------------------------------------------------------------------
+
+def _load_openrouter_key() -> str:
+    """Return the OpenRouter API key from env or ~/.config/model-ablation/env.
+
+    Key is read inline; it is never echoed or logged.
+    """
+    val = os.getenv("OPENROUTER_API_KEY")
+    if val:
+        return val
+    path = os.path.expanduser("~/.config/model-ablation/env")
+    with open(path) as fh:
+        for line in fh:
+            if "OPENROUTER_API_KEY" in line:
+                # handles: export OPENROUTER_API_KEY=sk-or-...
+                return line.strip().split("=", 1)[1].strip().strip('"').strip("'")
+    raise RuntimeError("OPENROUTER_API_KEY not found in environment or ~/.config/model-ablation/env")
+
+
+# ---------------------------------------------------------------------------
+# Per-provider dispatch functions (each returns {"text": str, "cost": float})
+# ---------------------------------------------------------------------------
+
+def _call_openrouter(model_id: str, prompt: str, seed: int) -> dict:
+    from openai import OpenAI  # lazy import — no network at module load
+    client = OpenAI(
+        base_url="https://openrouter.ai/api/v1",
+        api_key=_load_openrouter_key(),
+    )
+    resp = client.chat.completions.create(
+        model=model_id,
+        temperature=0,
+        seed=seed,
+        messages=[{"role": "user", "content": prompt}],
+    )
+    text = resp.choices[0].message.content or ""
+    # OpenRouter may report cost in resp.usage; fall back to 0.0
+    cost: float = 0.0
+    usage = getattr(resp, "usage", None)
+    if usage is not None:
+        cost = float(getattr(usage, "cost", None) or 0.0)
+    return {"text": text, "cost": cost}
+
+
+def _call_anthropic(model_id: str, prompt: str, seed: int) -> dict:
+    from anthropic import Anthropic  # lazy import
+    client = Anthropic()
+    resp = client.messages.create(
+        model=model_id,
+        max_tokens=256,
+        temperature=0,
+        messages=[{"role": "user", "content": prompt}],
+    )
+    text = resp.content[0].text if resp.content else ""
+    # Cost can be computed from usage × per-model price in the manifest;
+    # return 0.0 here and let the harness apply pricing post-hoc.
+    return {"text": text, "cost": 0.0}
+
+
+def _call_openai(model_id: str, prompt: str, seed: int) -> dict:
+    from openai import OpenAI  # lazy import
+    client = OpenAI()
+    resp = client.chat.completions.create(
+        model=model_id,
+        temperature=0,
+        seed=seed,
+        messages=[{"role": "user", "content": prompt}],
+    )
+    text = resp.choices[0].message.content or ""
+    return {"text": text, "cost": 0.0}
+
+
+# ---------------------------------------------------------------------------
+# Routing table  (maps provider name → function NAME in this module)
+# ---------------------------------------------------------------------------
+# We store the name rather than the function reference so that patch.object()
+# on _call_* attributes is honoured at call time (used in unit tests).
+
+_DISPATCH: dict[str, str] = {
+    "openrouter": "_call_openrouter",
+    "anthropic":  "_call_anthropic",
+    "openai":     "_call_openai",
+}
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def call_model(cfg: ModelCfg, prompt: str, seed: int = 0) -> tuple[str, float, float]:
+    """Call a model and return (text, cost_usd, latency_s).
+
+    temperature is always 0 for reproducibility.
+    Latency is wall-clock time around the SDK call.
+    The dispatch looks up the function by name at call time so that
+    unittest.mock.patch.object() on _call_* attributes works correctly in tests.
+    """
+    import sys
+    _mod = sys.modules[__name__]
+    fn = getattr(_mod, _DISPATCH[cfg.provider])
+    t0 = time.monotonic()
+    out: dict = fn(cfg.model_id, prompt, seed)
+    latency = time.monotonic() - t0
+    return out["text"], float(out.get("cost", 0.0)), latency

--- a/studies/annotation_reranking/model_call.py
+++ b/studies/annotation_reranking/model_call.py
@@ -17,6 +17,7 @@ Design notes
 """
 from __future__ import annotations
 
+import logging
 import os
 import time
 from dataclasses import dataclass, field
@@ -92,7 +93,21 @@ def _call_openrouter(model_id: str, prompt: str, seed: int) -> dict:
     cost: float = 0.0
     usage = getattr(resp, "usage", None)
     if usage is not None:
-        cost = float(getattr(usage, "cost", None) or 0.0)
+        raw_cost = getattr(usage, "cost", None)
+        if raw_cost:
+            cost = float(raw_cost)
+        else:
+            logging.getLogger(__name__).warning(
+                "OpenRouter response for model %s has no usage cost; recording 0.0 "
+                "(this is NOT a free call — cost data is unavailable).",
+                model_id,
+            )
+    else:
+        logging.getLogger(__name__).warning(
+            "OpenRouter response for model %s has no usage object; recording cost=0.0 "
+            "(this is NOT a free call — cost data is unavailable).",
+            model_id,
+        )
     return {"text": text, "cost": cost}
 
 

--- a/studies/annotation_reranking/models_data.py
+++ b/studies/annotation_reranking/models_data.py
@@ -1,0 +1,44 @@
+from dataclasses import dataclass, field
+
+
+@dataclass
+class Candidate:
+    id: str                       # CURIE, e.g. "CHEBI:28683"
+    score: float                  # Kestrel hybrid score (0-5)
+    name: str
+    synonyms: list[str] = field(default_factory=list)
+    prefixes: list[str] = field(default_factory=list)
+    equivalent_ids: list[str] = field(default_factory=list)  # enriched via get-nodes
+
+    def has_refmet(self) -> bool:
+        return any(e.startswith("RM:") for e in self.equivalent_ids)
+
+
+@dataclass
+class EvalCase:
+    name: str
+    level: str
+    refmet_id: str
+    refmet_name: str
+    biomapper_ids: list[str]
+    biomapper_name: str
+    category: str
+    correct_id: str | None
+    label_source: str
+    inchikey_block_correct: str | None = None
+    retrievable: bool | None = None
+
+
+@dataclass
+class RerankResult:
+    case_name: str
+    reranker: str
+    model: str | None
+    selected_id: str | None
+    correct_id: str | None
+    label_source: str
+    regime: str
+    is_correct: bool | None       # None when label_source == "refmet_agreement"
+    cost_usd: float
+    latency_s: float
+    error: str | None = None      # off-list / parse / api failure marker

--- a/studies/annotation_reranking/models_data.py
+++ b/studies/annotation_reranking/models_data.py
@@ -42,3 +42,4 @@ class RerankResult:
     cost_usd: float
     latency_s: float
     error: str | None = None      # off-list / parse / api failure marker
+    review_flag: str | None = None

--- a/studies/annotation_reranking/phase0.py
+++ b/studies/annotation_reranking/phase0.py
@@ -1,0 +1,167 @@
+"""Phase 0 decision gate for the annotation-reranking study.
+
+Measures — BEFORE any model spend — two signals:
+
+1. **Retrievability**: is the correct node even in the top-N candidate window?
+   (Spike measured ~45/172 cases with the target absent at limit=200.
+   Reranking cannot fix those.)
+
+2. **Divergence**: among retrievable cases, how many does the
+   ``source_weight_guard`` baseline flag for human review?  If the
+   retrievable-AND-flagged set is tiny, an LLM has almost no room to add
+   value → STOP and report before spending on the model matrix.
+
+Running this module LIVE hits Kestrel and (for flagged cases) the layered
+InChIKey resolver (MW/PubChem).  That is expected for the gate RUN and is
+NOT done in CI (unit tests mock all network calls).
+
+Usage (manual gate run)::
+
+    python -m studies.annotation_reranking.phase0
+
+or from Python::
+
+    from studies.annotation_reranking.phase0 import run_phase0
+    summary = run_phase0()
+"""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Imports from sibling modules (do NOT redefine)
+# ---------------------------------------------------------------------------
+from studies.annotation_reranking.dataset import dataset_sha256, load_eval_cases
+from studies.annotation_reranking.regimes import classify_regime, target_id
+from studies.annotation_reranking.rerankers import deterministic  # noqa: F401 — ensures REGISTRY is populated
+from studies.annotation_reranking.rerankers.base import REGISTRY
+from studies.annotation_reranking.retrieval import fetch_candidates
+
+# ---------------------------------------------------------------------------
+# Default paths
+# ---------------------------------------------------------------------------
+
+_HERE = Path(__file__).parent
+_DEFAULT_OUT_DIR = str(_HERE / "runs" / "phase0")
+
+# Default CSV path — the dataset with emoji + apostrophe in the directory name.
+_DEFAULT_CSV = (
+    "/home/trentleslie/Documents/Trent's Vault/"
+    "Active 🎯/Work/Projects/biomapper2 - refmet ChEBI analysis/"
+    "chebi_disagreements_cat.csv"
+)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def run_phase0(
+    csv_path: str = _DEFAULT_CSV,
+    top_n: int = 200,
+    out_dir: str | None = None,
+) -> dict:
+    """Run the Phase 0 gate and write ``phase0_regimes.json``.
+
+    Parameters
+    ----------
+    csv_path:
+        Path to the ChEBI disagreements CSV (172 rows).
+    top_n:
+        Number of Kestrel candidates to retrieve per compound.
+    out_dir:
+        Directory to write ``phase0_regimes.json``.  Defaults to
+        ``studies/annotation_reranking/runs/phase0``.
+
+    Returns
+    -------
+    dict
+        The summary sub-dict (also embedded in the JSON output).
+    """
+    effective_out_dir = out_dir if out_dir is not None else _DEFAULT_OUT_DIR
+
+    swg = REGISTRY["source_weight_guard"]
+    sha = dataset_sha256(csv_path)
+    cases = load_eval_cases(csv_path)
+
+    # Tallies
+    n_retrievable = 0
+    n_not_retrieved = 0
+    n_swg_disagrees = 0
+    flag_counts: dict[str, int] = {
+        "divergent_refmet": 0,
+        "conflict_no_structure": 0,
+        "none": 0,
+    }
+
+    per_case: list[dict] = []
+
+    for case in cases:
+        candidates = fetch_candidates(case.name, "metabolite", top_n)
+        regime = classify_regime(case, candidates)
+
+        if regime == "retrievable":
+            n_retrievable += 1
+            selected_id, review_flag = swg.select(candidates, case)
+
+            # Count flag distribution (only among retrievable)
+            flag_key = review_flag if review_flag in flag_counts else "none"
+            flag_counts[flag_key] += 1
+
+            # Disagreement: SWG selected something other than the target
+            tid = target_id(case)
+            if selected_id != tid:
+                n_swg_disagrees += 1
+        else:
+            n_not_retrieved += 1
+            selected_id, review_flag = None, None
+
+        per_case.append(
+            {
+                "name": case.name,
+                "regime": regime,
+                "target_id": target_id(case),
+                "selected_id": selected_id,
+                "review_flag": review_flag,
+            }
+        )
+
+    summary = {
+        "dataset_sha256": sha,
+        "top_n": top_n,
+        "total": len(cases),
+        "retrievable": n_retrievable,
+        "not_retrieved": n_not_retrieved,
+        "n_swg_disagrees_correct": n_swg_disagrees,
+        "flag_divergent_refmet": flag_counts["divergent_refmet"],
+        "flag_conflict_no_structure": flag_counts["conflict_no_structure"],
+        "flag_none": flag_counts["none"],
+    }
+
+    output = {"summary": summary, "per_case": per_case}
+
+    # Write JSON
+    out_path = Path(effective_out_dir)
+    out_path.mkdir(parents=True, exist_ok=True)
+    json_file = out_path / "phase0_regimes.json"
+    with open(json_file, "w", encoding="utf-8") as fh:
+        json.dump(output, fh, indent=2)
+
+    # Print summary + path
+    print("\n=== Phase 0 Summary ===")
+    for k, v in summary.items():
+        print(f"  {k}: {v}")
+    print(f"\nPhase 0 results written to: {json_file}")
+
+    return summary
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    run_phase0()

--- a/studies/annotation_reranking/phase0.py
+++ b/studies/annotation_reranking/phase0.py
@@ -107,7 +107,9 @@ def run_phase0(
             n_retrievable += 1
             selected_id, review_flag = swg.select(candidates, case)
 
-            # Count flag distribution (only among retrievable)
+            # Count flag distribution (only among retrievable).
+            # Any flag not in flag_counts (including None or future flags) collapses
+            # to "none" — intentional: unknown flags should not crash the gate run.
             flag_key = review_flag if review_flag in flag_counts else "none"
             flag_counts[flag_key] += 1
 

--- a/studies/annotation_reranking/regimes.py
+++ b/studies/annotation_reranking/regimes.py
@@ -1,0 +1,54 @@
+"""Retrievability + divergence tagging for the annotation-reranking study.
+
+Provides per-case regime classification used by the Phase 0 gate and the
+orchestrator (Task 8).
+
+Functions
+---------
+target_id(case) -> str
+    The node a reranker must select to be considered correct.
+
+is_retrievable(case, candidates) -> bool
+    True iff target_id(case) appears in the candidate list.
+
+classify_regime(case, candidates) -> str
+    Returns "retrievable" or "not_retrieved".
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from studies.annotation_reranking.models_data import Candidate, EvalCase
+
+
+def target_id(case: "EvalCase") -> str:
+    """Return the CURIE the reranker must pick to be correct.
+
+    Priority:
+      1. ``case.correct_id`` if set (independently adjudicated).
+      2. ``f"CHEBI:{case.refmet_id.strip()}"`` — RefMet's node, matching the
+         spike's recall measurement baseline.
+    """
+    if case.correct_id is not None:
+        return case.correct_id
+    return f"CHEBI:{case.refmet_id.strip()}"
+
+
+def is_retrievable(case: "EvalCase", candidates: "list[Candidate]") -> bool:
+    """Return True iff the target node appears in *candidates*."""
+    tid = target_id(case)
+    return any(c.id == tid for c in candidates)
+
+
+def classify_regime(case: "EvalCase", candidates: "list[Candidate]") -> str:
+    """Classify this (case, candidate-set) pair into a regime tag.
+
+    Returns
+    -------
+    "retrievable"
+        The target node is present in the candidate window; reranking may help.
+    "not_retrieved"
+        The target node is absent; reranking cannot fix this case.
+    """
+    return "retrievable" if is_retrievable(case, candidates) else "not_retrieved"

--- a/studies/annotation_reranking/rerankers/__init__.py
+++ b/studies/annotation_reranking/rerankers/__init__.py
@@ -1,0 +1,1 @@
+"""Annotation-reranking reranker package."""

--- a/studies/annotation_reranking/rerankers/base.py
+++ b/studies/annotation_reranking/rerankers/base.py
@@ -1,0 +1,43 @@
+"""Base Reranker protocol and shared registry for annotation-reranking study."""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from studies.annotation_reranking.models_data import Candidate, EvalCase
+
+
+@runtime_checkable
+class Reranker(Protocol):
+    """Protocol all rerankers must satisfy.
+
+    ``select`` carries optional case context so rerankers can use ground-truth
+    signals (e.g. refmet_id) at inference time.  It returns a 2-tuple:
+      - ``selected_id``: the winning CURIE (or None when candidates is empty).
+      - ``review_flag``: a short label string when the call warrants human review,
+        otherwise None.
+
+    Deterministic rerankers (top1, rm_anchor) ignore ``case`` and always return
+    ``(selected_id, None)``.  LLM and guard rerankers (source_weight_guard, Task 5+)
+    may use ``case`` and may return non-None flags.
+
+    This signature is the standard all future rerankers AND the orchestrator
+    (Task 8) must follow.
+    """
+
+    name: str
+
+    def select(
+        self,
+        candidates: "list[Candidate]",
+        case: "EvalCase | None" = None,
+    ) -> "tuple[str | None, str | None]":
+        ...
+
+
+REGISTRY: dict[str, Reranker] = {}
+
+
+def register(r: Reranker) -> Reranker:
+    REGISTRY[r.name] = r
+    return r

--- a/studies/annotation_reranking/rerankers/deterministic.py
+++ b/studies/annotation_reranking/rerankers/deterministic.py
@@ -1,0 +1,131 @@
+"""Deterministic rerankers for the annotation-reranking study.
+
+Contains:
+  - Top1Reranker: always pick the highest-scoring candidate.
+  - RmAnchorReranker: prefer RM-bearing candidates; fall back to highest score.
+  - SourceWeightGuardReranker: primary metabolite baseline — the rule the LLM
+      must beat.  Compares the resolver majority vote against the RefMet anchor
+      using 2-D InChIKey connectivity.
+
+All rerankers implement the Reranker protocol from `base.py`:
+  select(candidates, case=None) -> (selected_id, review_flag)
+
+REGISTRY entries are available for orchestration by name.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Callable
+
+from studies.annotation_reranking.inchikey_resolver import connectivity_match
+from studies.annotation_reranking.rerankers.base import register
+
+if TYPE_CHECKING:
+    from studies.annotation_reranking.models_data import Candidate, EvalCase
+
+
+class Top1Reranker:
+    """Select the candidate with the highest score.
+
+    Ignores ``case``.  Always returns ``(selected_id, None)``.
+    """
+
+    name = "top1"
+
+    def select(
+        self,
+        candidates: list[Candidate],
+        case: EvalCase | None = None,
+    ) -> tuple[str | None, str | None]:
+        if not candidates:
+            return None, None
+        return max(candidates, key=lambda c: c.score).id, None
+
+
+class RmAnchorReranker:
+    """Prefer RefMet-bearing candidates; fall back to highest score.
+
+    Among multiple RM-bearing candidates, choose the lexicographically smallest
+    CURIE for a deterministic, reproducible tie-break.
+
+    Ignores ``case``.  Always returns ``(selected_id, None)``.
+    """
+
+    name = "rm_anchor"
+
+    def select(
+        self,
+        candidates: list[Candidate],
+        case: EvalCase | None = None,
+    ) -> tuple[str | None, str | None]:
+        if not candidates:
+            return None, None
+        rm = [c for c in candidates if c.has_refmet()]
+        if rm:
+            return min(rm, key=lambda c: c.id).id, None
+        return max(candidates, key=lambda c: c.score).id, None
+
+
+class SourceWeightGuardReranker:
+    """Primary metabolite baseline — the rule the LLM must beat.
+
+    Algorithm (Revision 2026-07-08):
+      1. ``majority`` = highest-scoring candidate (proxy for resolver vote).
+      2. If ``case`` is None or ``case.refmet_id`` is empty → return majority,
+         no flag.
+      3. Build ``refmet_curie = f"CHEBI:{case.refmet_id}"`` and look it up in
+         candidates.
+      4. If refmet not found, or refmet IS majority → return majority, no flag.
+      5. Run ``connectivity_fn(refmet.id, refmet.name, majority.id, majority.name)``:
+         - True  → same molecule, silently prefer refmet.
+         - False → error-prone bucket, prefer refmet + flag "divergent_refmet".
+         - None  → unresolvable, keep majority + flag "conflict_no_structure".
+
+    Inject ``connectivity_fn`` for testability (never hit the real network in
+    unit tests).  The module-level REGISTRY entry uses the real
+    ``connectivity_match`` from inchikey_resolver.
+    """
+
+    name = "source_weight_guard"
+
+    def __init__(
+        self,
+        connectivity_fn: Callable[[str, str, str, str], bool | None],
+    ) -> None:
+        self._match = connectivity_fn
+
+    def select(
+        self,
+        candidates: list[Candidate],
+        case: EvalCase | None = None,
+    ) -> tuple[str | None, str | None]:
+        if not candidates:
+            return None, "empty_candidates"
+
+        majority = max(candidates, key=lambda c: c.score)
+
+        if case is None or not case.refmet_id:
+            return majority.id, None
+
+        refmet_curie = f"CHEBI:{case.refmet_id}"
+        refmet = next((c for c in candidates if c.id == refmet_curie), None)
+
+        if refmet is None or refmet.id == majority.id:
+            return majority.id, None
+
+        same = self._match(refmet.id, refmet.name, majority.id, majority.name)
+        if same is True:
+            return refmet.id, None
+        if same is False:
+            return refmet.id, "divergent_refmet"
+        return majority.id, "conflict_no_structure"
+
+
+# ---------------------------------------------------------------------------
+# Register instances — deterministic rerankers use no arguments.
+# source_weight_guard uses the real connectivity_match for production use;
+# tests construct SourceWeightGuardReranker with a mock fn directly.
+# ---------------------------------------------------------------------------
+
+register(Top1Reranker())
+register(RmAnchorReranker())
+register(SourceWeightGuardReranker(connectivity_match))

--- a/studies/annotation_reranking/rerankers/deterministic.py
+++ b/studies/annotation_reranking/rerankers/deterministic.py
@@ -26,7 +26,9 @@ if TYPE_CHECKING:
 class Top1Reranker:
     """Select the candidate with the highest score.
 
-    Ignores ``case``.  Always returns ``(selected_id, None)``.
+    Ignores ``case``.  Always returns ``(selected_id, None)``.  A tie on
+    ``score`` resolves to whichever candidate appears first in ``candidates``
+    (input-order-dependent).
     """
 
     name = "top1"
@@ -70,6 +72,8 @@ class SourceWeightGuardReranker:
 
     Algorithm (Revision 2026-07-08):
       1. ``majority`` = highest-scoring candidate (proxy for resolver vote).
+         A tie on ``score`` resolves to whichever candidate appears first in
+         ``candidates`` (input-order-dependent).
       2. If ``case`` is None or ``case.refmet_id`` is empty → return majority,
          no flag.
       3. Build ``refmet_curie = f"CHEBI:{case.refmet_id}"`` and look it up in
@@ -106,7 +110,7 @@ class SourceWeightGuardReranker:
         if case is None or not case.refmet_id:
             return majority.id, None
 
-        refmet_curie = f"CHEBI:{case.refmet_id}"
+        refmet_curie = f"CHEBI:{case.refmet_id.strip()}"
         refmet = next((c for c in candidates if c.id == refmet_curie), None)
 
         if refmet is None or refmet.id == majority.id:

--- a/studies/annotation_reranking/rerankers/llm.py
+++ b/studies/annotation_reranking/rerankers/llm.py
@@ -33,6 +33,13 @@ _INSTRUCTION = (
 
 
 def _serialize(c: "Candidate", blind_rm: bool) -> str:
+    # Blinding removes RM: anchor ids from equivalent_ids only.
+    # c.name is the KG/ChEBI node's own name from Kestrel hybrid-search —
+    # retained as a legitimate reranking signal (it is NOT a RefMet-specific
+    # field and stripping it would cripple the reranker).
+    # Note: residual name-similarity between a candidate name and the query is
+    # an inherent, un-blindable signal — documented as a study limitation, not
+    # a leak to strip.
     equiv = [e for e in c.equivalent_ids if not (blind_rm and e.startswith("RM:"))]
     return f"- {c.id} | name={c.name} | score={c.score} | equivalent_ids={equiv}"
 
@@ -41,7 +48,8 @@ def build_prompt(candidates: "list[Candidate]", blind_rm: bool) -> str:
     """Build the LLM prompt from a list of candidates.
 
     When blind_rm=True, strips RM: entries from equivalent_ids so the model
-    cannot key on the RefMet anchor.
+    cannot key on the RefMet anchor.  The candidate name field is always
+    included — see _serialize for the rationale.
     """
     lines = "\n".join(_serialize(c, blind_rm) for c in candidates)
     return f"{_INSTRUCTION}\n\nCandidates:\n{lines}\n\nAnswer with one CURIE:"

--- a/studies/annotation_reranking/rerankers/llm.py
+++ b/studies/annotation_reranking/rerankers/llm.py
@@ -1,0 +1,101 @@
+"""LLM reranker for the annotation-reranking study.
+
+Provides:
+  - build_prompt(candidates, blind_rm) -> str
+      Serializes candidates into a prompt.  When blind_rm=True, strips any
+      equivalent_ids entries starting with "RM:" so the model cannot key on
+      the RefMet anchor feature.
+
+  - parse_selection(text, candidates) -> str | None
+      Extracts the first CHEBI CURIE from the model's text response that is
+      present in the candidate list.  Returns None for off-list or malformed
+      responses.
+
+  - LlmReranker(model_name, call_fn, blind_rm)
+      Wraps build_prompt + parse_selection with an injected call_fn so tests
+      can stub the LLM without real API calls.
+
+      Protocol (Revision 2026-07-08): select() returns (selected_id, None).
+      LLM rerankers never emit a review flag.
+"""
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from studies.annotation_reranking.models_data import Candidate, EvalCase
+
+_INSTRUCTION = (
+    "You are matching a metabolite query to the single best knowledge-graph node.\n"
+    "Choose exactly one candidate. Respond with ONLY its CHEBI CURIE (e.g. CHEBI:12345)."
+)
+
+
+def _serialize(c: "Candidate", blind_rm: bool) -> str:
+    equiv = [e for e in c.equivalent_ids if not (blind_rm and e.startswith("RM:"))]
+    return f"- {c.id} | name={c.name} | score={c.score} | equivalent_ids={equiv}"
+
+
+def build_prompt(candidates: "list[Candidate]", blind_rm: bool) -> str:
+    """Build the LLM prompt from a list of candidates.
+
+    When blind_rm=True, strips RM: entries from equivalent_ids so the model
+    cannot key on the RefMet anchor.
+    """
+    lines = "\n".join(_serialize(c, blind_rm) for c in candidates)
+    return f"{_INSTRUCTION}\n\nCandidates:\n{lines}\n\nAnswer with one CURIE:"
+
+
+def parse_selection(text: str, candidates: "list[Candidate]") -> str | None:
+    """Extract the winning CURIE from the model's response.
+
+    Scans for CHEBI:\\d+ tokens in order of appearance and returns the first
+    that is present in the candidate list.  Returns None if no in-list CURIE
+    is found (off-list hallucination or unrecognised format).
+    """
+    ids = {c.id for c in candidates}
+    for m in re.findall(r"CHEBI:\d+", text):
+        if m in ids:
+            return m
+    return None
+
+
+class LlmReranker:
+    """LLM-based reranker with injected call_fn for testability.
+
+    Parameters
+    ----------
+    model_name:
+        Identifier string (e.g. "sonnet", "opus") used to construct `.name`
+        and forwarded to call_fn.
+    call_fn:
+        Callable ``(model_name: str, prompt: str) -> str`` that returns the
+        model's raw text response.  Injected so tests can stub without real
+        API calls.
+    blind_rm:
+        When True, strip RM: entries from the prompt (RM-blinding condition).
+
+    Protocol (Revision 2026-07-08)
+    --------------------------------
+    ``select(candidates, case=None) -> tuple[str | None, str | None]``
+    LLM rerankers never emit a review flag, so the second element is always
+    None.  Returns ``(None, None)`` when candidates is empty.
+    """
+
+    def __init__(self, model_name: str, call_fn, blind_rm: bool) -> None:
+        self.model_name = model_name
+        self.call_fn = call_fn   # (model_name, prompt) -> str
+        self.blind_rm = blind_rm
+        self.name = f"llm:{model_name}{'/blind' if blind_rm else ''}"
+
+    def select(
+        self,
+        candidates: "list[Candidate]",
+        case: "EvalCase | None" = None,
+    ) -> tuple[str | None, str | None]:
+        if not candidates:
+            return None, None
+        prompt = build_prompt(candidates, self.blind_rm)
+        text = self.call_fn(self.model_name, prompt)
+        return parse_selection(text, candidates), None

--- a/studies/annotation_reranking/retrieval.py
+++ b/studies/annotation_reranking/retrieval.py
@@ -1,0 +1,59 @@
+"""Top-N candidate retrieval with equivalent_ids enrichment.
+
+Calls KestrelHybridSearchAnnotator._kestrel_hybrid_search directly, bypassing
+the production get_annotations path (which hardcodes limit=1).
+
+The _raw_hybrid_search and _fetch_equivalent_ids module-level functions are the
+seam patched by unit tests — keep them as thin wrappers so mock.patch.object
+works correctly.
+
+Note on Linker.get_equivalent_ids return shape:
+    The real API returns dict[str, dict[str, list[str]]], i.e.
+        {"CHEBI:15365": {"HMDB": ["HMDB0001879"], "RM": ["0001"]}}
+    _fetch_equivalent_ids flattens this to dict[str, list[str]], i.e.
+        {"CHEBI:15365": ["HMDB:HMDB0001879", "RM:0001"]}
+    so that Candidate.equivalent_ids contains full CURIEs and has_refmet() works.
+"""
+from biomapper2.core.annotators.kestrel_hybrid import KestrelHybridSearchAnnotator
+from biomapper2.core.linker import Linker
+from studies.annotation_reranking.models_data import Candidate
+
+
+def _raw_hybrid_search(text: str, category: str, prefixes, limit: int) -> dict:
+    """Bypasses production get_annotations (which hardcodes limit=1) on purpose."""
+    return KestrelHybridSearchAnnotator._kestrel_hybrid_search(text, category, prefixes, limit=limit)
+
+
+def _fetch_equivalent_ids(ids: list[str]) -> dict[str, list[str]]:
+    """Wrap Linker.get_equivalent_ids; return {curie: [flat equivalent CURIEs]}.
+
+    Linker returns {curie: {prefix: [local_ids]}}, so we reconstruct full CURIEs
+    by joining prefix + ":" + local_id.
+    """
+    nested = Linker.get_equivalent_ids(ids)
+    result: dict[str, list[str]] = {}
+    for curie, prefix_map in nested.items():
+        flat: list[str] = []
+        for prefix, local_ids in prefix_map.items():
+            for local_id in local_ids:
+                flat.append(f"{prefix}:{local_id}")
+        result[curie] = flat
+    return result
+
+
+def fetch_candidates(name: str, category: str, top_n: int = 20) -> list[Candidate]:
+    """Return up to top_n scored Kestrel candidates enriched with equivalent_ids."""
+    raw = _raw_hybrid_search(name, category, None, limit=top_n).get(name, [])
+    ids = [r["id"] for r in raw]
+    equiv = _fetch_equivalent_ids(ids) if ids else {}
+    return [
+        Candidate(
+            id=r["id"],
+            score=float(r["score"]),
+            name=r["name"],
+            synonyms=r.get("synonyms", []),
+            prefixes=r.get("prefixes", []),
+            equivalent_ids=equiv.get(r["id"], []),
+        )
+        for r in raw
+    ]

--- a/studies/annotation_reranking/run.py
+++ b/studies/annotation_reranking/run.py
@@ -35,6 +35,7 @@ import random
 from typing import TYPE_CHECKING
 
 from studies.annotation_reranking.dataset import dataset_sha256, load_eval_cases
+from studies.annotation_reranking import labels as _labels_module
 from studies.annotation_reranking.model_call import ROSTER, call_model
 from studies.annotation_reranking.models_data import RerankResult
 from studies.annotation_reranking.regimes import classify_regime
@@ -187,6 +188,7 @@ def run_matrix(
     seeds: tuple[int, ...] | list[int] = (0, 1, 2),
     out_dir: str | None = None,
     hardware: str = "unspecified",
+    derive_labels: bool = False,
 ) -> str:
     """Run the full annotation-reranking matrix and write outputs to *out_dir*.
 
@@ -208,6 +210,10 @@ def run_matrix(
         ``studies/annotation_reranking/runs/<UTC-timestamp>``.
     hardware:
         Free-form descriptor for the run host (e.g. "A100-40G").
+    derive_labels:
+        When True, call ``labels.derive_labels(cases)`` right after
+        ``load_eval_cases`` to derive structural labels from InChIKey
+        connectivity.  Disabled by default (gate-time live run step).
 
     Returns
     -------
@@ -234,6 +240,8 @@ def run_matrix(
         json.dump(manifest, fh, indent=2)
 
     cases = load_eval_cases(csv_path)
+    if derive_labels:
+        _labels_module.derive_labels(cases)
     results_path = os.path.join(out_dir, "results.jsonl")
 
     with open(results_path, "w", encoding="utf-8") as fh:
@@ -342,6 +350,16 @@ if __name__ == "__main__":
         default="unspecified",
         help="Free-form hardware descriptor for the manifest (default: unspecified).",
     )
+    ap.add_argument(
+        "--derive-labels",
+        action="store_true",
+        default=False,
+        help=(
+            "Derive structural labels from InChIKey connectivity (MW + PubChem) "
+            "for disagreement cases before scoring.  Requires live network access. "
+            "Disabled by default."
+        ),
+    )
     a = ap.parse_args()
 
     model_labels = [x for x in a.models.split(",") if x]
@@ -349,5 +367,5 @@ if __name__ == "__main__":
         _register_llms(model_labels)  # always registers both blind + non-blind variants
 
     seeds = tuple(int(s) for s in a.seeds.split(","))
-    path = run_matrix(a.csv, a.top_n, seeds, a.out, a.hardware)
+    path = run_matrix(a.csv, a.top_n, seeds, a.out, a.hardware, a.derive_labels)
     print(path)

--- a/studies/annotation_reranking/run.py
+++ b/studies/annotation_reranking/run.py
@@ -9,7 +9,7 @@ score_case(case, candidates, reranker, model_label) -> RerankResult
     Pure function; handles all shadow paths (empty candidates, off-list
     None, exception from reranker, cost/latency seam for LLM rerankers).
 
-_register_llms(model_labels, blind=True) -> None
+_register_llms(model_labels) -> None
     Register LlmReranker instances (blind + non-blind) for each label in
     model_labels, wiring call_model into each reranker's call_fn so that
     last_cost_usd / last_latency_s are populated after select().
@@ -255,7 +255,7 @@ def run_matrix(
 # LLM registration (Task 9)
 # ---------------------------------------------------------------------------
 
-def _register_llms(model_labels: list[str], blind: bool = True) -> None:
+def _register_llms(model_labels: list[str]) -> None:
     """Register LlmReranker instances for each label in *model_labels*.
 
     For each label two rerankers are added to the REGISTRY:
@@ -346,7 +346,7 @@ if __name__ == "__main__":
 
     model_labels = [x for x in a.models.split(",") if x]
     if model_labels:
-        _register_llms(model_labels)
+        _register_llms(model_labels)  # always registers both blind + non-blind variants
 
     seeds = tuple(int(s) for s in a.seeds.split(","))
     path = run_matrix(a.csv, a.top_n, seeds, a.out, a.hardware)

--- a/studies/annotation_reranking/run.py
+++ b/studies/annotation_reranking/run.py
@@ -1,4 +1,4 @@
-"""Matrix orchestrator for the annotation-reranking study (Task 8).
+"""Matrix orchestrator for the annotation-reranking study (Tasks 8–9).
 
 Entry points
 ------------
@@ -8,6 +8,11 @@ build_manifest(csv_path, top_n, seeds, roster, hardware) -> dict
 score_case(case, candidates, reranker, model_label) -> RerankResult
     Pure function; handles all shadow paths (empty candidates, off-list
     None, exception from reranker, cost/latency seam for LLM rerankers).
+
+_register_llms(model_labels, blind=True) -> None
+    Register LlmReranker instances (blind + non-blind) for each label in
+    model_labels, wiring call_model into each reranker's call_fn so that
+    last_cost_usd / last_latency_s are populated after select().
 
 run_matrix(csv_path, top_n=20, seeds=(0,1,2), out_dir=None, hardware="unspecified") -> str
     Full orchestration: load dataset, fetch candidates, shuffle per seed,
@@ -30,6 +35,7 @@ import random
 from typing import TYPE_CHECKING
 
 from studies.annotation_reranking.dataset import dataset_sha256, load_eval_cases
+from studies.annotation_reranking.model_call import ROSTER, call_model
 from studies.annotation_reranking.models_data import RerankResult
 from studies.annotation_reranking.regimes import classify_regime
 from studies.annotation_reranking.retrieval import fetch_candidates
@@ -243,3 +249,105 @@ def run_matrix(
 
     print(f"[run] results saved to {out_dir}")
     return out_dir
+
+
+# ---------------------------------------------------------------------------
+# LLM registration (Task 9)
+# ---------------------------------------------------------------------------
+
+def _register_llms(model_labels: list[str], blind: bool = True) -> None:
+    """Register LlmReranker instances for each label in *model_labels*.
+
+    For each label two rerankers are added to the REGISTRY:
+      - ``llm:<label>/blind`` — RM: entries stripped from the prompt.
+      - ``llm:<label>``       — un-blinded (retains RM: anchor ids).
+
+    ``call_model`` is imported lazily (only called at select-time) so that
+    importing this module never touches network or API keys.
+
+    The call_fn closure captures *cfg* and *r* by reference using default
+    arguments to freeze each loop variable — a classic Python closure gotcha.
+    ``last_cost_usd`` and ``last_latency_s`` are initialised to 0.0 so that
+    ``score_case`` (which reads them immediately after register) always has a
+    valid float, even before the first select() call.
+    """
+    from studies.annotation_reranking.rerankers.base import register
+    from studies.annotation_reranking.rerankers.llm import LlmReranker
+
+    by_label = {c.label: c for c in ROSTER}
+    for label in model_labels:
+        cfg = by_label[label]   # raises KeyError for unknown labels — intentional
+        for blind_rm in (True, False):
+            r = LlmReranker(cfg.label, call_fn=None, blind_rm=blind_rm)
+            r.last_cost_usd = 0.0
+            r.last_latency_s = 0.0
+
+            def _call_fn(model: str, prompt: str, _cfg=cfg, _r=r) -> str:
+                text, cost, latency = call_model(_cfg, prompt)
+                _r.last_cost_usd = cost
+                _r.last_latency_s = latency
+                return text
+
+            r.call_fn = _call_fn
+            register(r)
+
+
+# ---------------------------------------------------------------------------
+# CLI entrypoint (Task 9)
+# ---------------------------------------------------------------------------
+
+_DEFAULT_CSV = (
+    "/home/trentleslie/Documents/Trent's Vault/"
+    "Active 🎯/Work/Projects/biomapper2 - refmet ChEBI analysis/"
+    "chebi_disagreements_cat.csv"
+)
+
+if __name__ == "__main__":
+    import argparse
+
+    ap = argparse.ArgumentParser(
+        description="Run the annotation-reranking matrix.",
+    )
+    ap.add_argument(
+        "--csv",
+        default=_DEFAULT_CSV,
+        help="Path to ChEBI disagreement CSV (default: Global-Constraints vault path).",
+    )
+    ap.add_argument(
+        "--top-n",
+        type=int,
+        default=20,
+        help="Candidate window size for Kestrel retrieval (default: 20).",
+    )
+    ap.add_argument(
+        "--seeds",
+        default="0,1,2",
+        help="Comma-separated RNG seeds for candidate shuffles (default: 0,1,2).",
+    )
+    ap.add_argument(
+        "--models",
+        default="",
+        help=(
+            "Comma-separated model labels from ROSTER to include as LLM rerankers "
+            "(e.g. sonnet,qwen3-8b). Empty = deterministic rerankers only."
+        ),
+    )
+    ap.add_argument(
+        "--out",
+        default=None,
+        help="Output directory (default: studies/annotation_reranking/runs/<UTC>).",
+    )
+    ap.add_argument(
+        "--hardware",
+        default="unspecified",
+        help="Free-form hardware descriptor for the manifest (default: unspecified).",
+    )
+    a = ap.parse_args()
+
+    model_labels = [x for x in a.models.split(",") if x]
+    if model_labels:
+        _register_llms(model_labels)
+
+    seeds = tuple(int(s) for s in a.seeds.split(","))
+    path = run_matrix(a.csv, a.top_n, seeds, a.out, a.hardware)
+    print(path)

--- a/studies/annotation_reranking/run.py
+++ b/studies/annotation_reranking/run.py
@@ -232,7 +232,7 @@ def run_matrix(
 
     with open(results_path, "w", encoding="utf-8") as fh:
         for case in cases:
-            candidates = fetch_candidates(case.name, case.category, top_n=top_n)
+            candidates = fetch_candidates(case.name, "metabolite", top_n=top_n)
             for seed in seeds:
                 rng = random.Random(seed)
                 shuffled = candidates[:]

--- a/studies/annotation_reranking/run.py
+++ b/studies/annotation_reranking/run.py
@@ -1,0 +1,245 @@
+"""Matrix orchestrator for the annotation-reranking study (Task 8).
+
+Entry points
+------------
+build_manifest(csv_path, top_n, seeds, roster, hardware) -> dict
+    Pure function; pins all reproducibility fields for a run.
+
+score_case(case, candidates, reranker, model_label) -> RerankResult
+    Pure function; handles all shadow paths (empty candidates, off-list
+    None, exception from reranker, cost/latency seam for LLM rerankers).
+
+run_matrix(csv_path, top_n=20, seeds=(0,1,2), out_dir=None, hardware="unspecified") -> str
+    Full orchestration: load dataset, fetch candidates, shuffle per seed,
+    score every (case × seed × reranker) triple, write results.jsonl +
+    manifest.json to a timestamped directory, return the path.
+
+Amendment notes (2026-07-08)
+----------------------------
+- classify_regime takes (case, candidates) — 2-arg form.
+- reranker.select returns a 2-tuple (selected_id, review_flag).
+- cost_usd and latency_s are read from reranker.last_cost_usd /
+  reranker.last_latency_s AFTER select; defaults to 0.0 when absent.
+"""
+from __future__ import annotations
+
+import datetime
+import json
+import os
+import random
+from typing import TYPE_CHECKING
+
+from studies.annotation_reranking.dataset import dataset_sha256, load_eval_cases
+from studies.annotation_reranking.models_data import RerankResult
+from studies.annotation_reranking.regimes import classify_regime
+from studies.annotation_reranking.retrieval import fetch_candidates
+from studies.annotation_reranking.rerankers.base import REGISTRY
+
+if TYPE_CHECKING:
+    from studies.annotation_reranking.models_data import Candidate, EvalCase
+    from studies.annotation_reranking.rerankers.base import Reranker
+
+
+# ---------------------------------------------------------------------------
+# build_manifest
+# ---------------------------------------------------------------------------
+
+def build_manifest(
+    csv_path: str,
+    top_n: int,
+    seeds: tuple[int, ...] | list[int],
+    roster: list,
+    hardware: str,
+) -> dict:
+    """Return a dict that pins every reproducibility field for a run.
+
+    Parameters
+    ----------
+    csv_path:
+        Path to the eval CSV; used only for SHA-256 pinning (may not exist
+        when called with a placeholder path — sha256 is None in that case).
+    top_n:
+        Candidate window size passed to fetch_candidates.
+    seeds:
+        RNG seeds used for candidate shuffles (position-bias control).
+    roster:
+        List of reranker/model config objects.  ``model_id`` attribute is
+        used when present; str(obj) otherwise.  May be empty.
+    hardware:
+        Free-form hardware descriptor for the run host.
+    """
+    sha = dataset_sha256(csv_path) if os.path.exists(csv_path) else None
+    models = [getattr(obj, "model_id", str(obj)) for obj in roster]
+    quant_notes = {
+        getattr(obj, "label", ""): getattr(obj, "quant_note", "")
+        for obj in roster
+    }
+    return {
+        "dataset_sha256": sha,
+        "top_n": top_n,
+        "seeds": list(seeds),
+        "temperature": 0,
+        "models": models,
+        "quant_notes": quant_notes,
+        "hardware": hardware,
+    }
+
+
+# ---------------------------------------------------------------------------
+# score_case
+# ---------------------------------------------------------------------------
+
+def score_case(
+    case: "EvalCase",
+    candidates: "list[Candidate]",
+    reranker: "Reranker",
+    model_label: str | None,
+) -> RerankResult:
+    """Score a single (case, candidate-set) pair with *reranker*.
+
+    Shadow-path rules
+    -----------------
+    - Empty candidates  → error="empty_candidates", is_correct=False, selected_id=None.
+    - Reranker exception → error=str(e), is_correct=False, selected_id=None.
+    - selected is None  → error="off_list", is_correct=False.
+    - correct_id is None → is_correct=None (refmet_agreement; unscored).
+    - Otherwise is_correct = (selected == case.correct_id).
+
+    Cost/latency seam
+    -----------------
+    After calling select(), reads ``reranker.last_cost_usd`` and
+    ``reranker.last_latency_s`` (both default to 0.0 when absent).  This lets
+    the LLM reranker (Task 9) populate these per-call without changing the
+    orchestrator.
+    """
+    regime = classify_regime(case, candidates)
+
+    base_kwargs = dict(
+        case_name=case.name,
+        reranker=reranker.name,
+        model=model_label,
+        correct_id=case.correct_id,
+        label_source=case.label_source,
+        regime=regime,
+        cost_usd=0.0,
+        latency_s=0.0,
+    )
+
+    if not candidates:
+        return RerankResult(
+            selected_id=None,
+            is_correct=False,
+            error="empty_candidates",
+            review_flag=None,
+            **base_kwargs,
+        )
+
+    try:
+        selected, review_flag = reranker.select(candidates, case)
+    except Exception as exc:
+        return RerankResult(
+            selected_id=None,
+            is_correct=False,
+            error=str(exc),
+            review_flag=None,
+            **base_kwargs,
+        )
+
+    # Read cost/latency seam AFTER select (may have been set by LLM reranker).
+    cost_usd = getattr(reranker, "last_cost_usd", 0.0)
+    latency_s = getattr(reranker, "last_latency_s", 0.0)
+    base_kwargs["cost_usd"] = cost_usd
+    base_kwargs["latency_s"] = latency_s
+
+    if selected is None:
+        return RerankResult(
+            selected_id=None,
+            is_correct=False,
+            error="off_list",
+            review_flag=review_flag,
+            **base_kwargs,
+        )
+
+    is_correct = None if case.correct_id is None else (selected == case.correct_id)
+
+    return RerankResult(
+        selected_id=selected,
+        is_correct=is_correct,
+        error=None,
+        review_flag=review_flag,
+        **base_kwargs,
+    )
+
+
+# ---------------------------------------------------------------------------
+# run_matrix
+# ---------------------------------------------------------------------------
+
+def run_matrix(
+    csv_path: str,
+    top_n: int = 20,
+    seeds: tuple[int, ...] | list[int] = (0, 1, 2),
+    out_dir: str | None = None,
+    hardware: str = "unspecified",
+) -> str:
+    """Run the full annotation-reranking matrix and write outputs to *out_dir*.
+
+    Iterates every (case × seed × reranker) triple:
+    - Candidates are shuffled per seed for position-bias counterbalancing.
+    - Results are written as JSONL (one RerankResult per line).
+    - A manifest.json pinning all reproducibility fields is written first.
+
+    Parameters
+    ----------
+    csv_path:
+        Path to the ChEBI disagreement CSV.
+    top_n:
+        Candidate window size for Kestrel retrieval.
+    seeds:
+        RNG seeds for candidate shuffles.
+    out_dir:
+        Output directory.  Defaults to
+        ``studies/annotation_reranking/runs/<UTC-timestamp>``.
+    hardware:
+        Free-form descriptor for the run host (e.g. "A100-40G").
+
+    Returns
+    -------
+    str
+        Absolute path to *out_dir*.
+    """
+    if out_dir is None:
+        stamp = datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        out_dir = os.path.join(
+            os.path.dirname(__file__), "runs", stamp
+        )
+
+    os.makedirs(out_dir, exist_ok=True)
+
+    # Write manifest before results so partial runs are still inspectable.
+    manifest = build_manifest(
+        csv_path=csv_path,
+        top_n=top_n,
+        seeds=seeds,
+        roster=list(REGISTRY.values()),
+        hardware=hardware,
+    )
+    with open(os.path.join(out_dir, "manifest.json"), "w", encoding="utf-8") as fh:
+        json.dump(manifest, fh, indent=2)
+
+    cases = load_eval_cases(csv_path)
+    results_path = os.path.join(out_dir, "results.jsonl")
+
+    with open(results_path, "w", encoding="utf-8") as fh:
+        for case in cases:
+            candidates = fetch_candidates(case.name, case.category, top_n=top_n)
+            for seed in seeds:
+                rng = random.Random(seed)
+                shuffled = candidates[:]
+                rng.shuffle(shuffled)  # position-bias control
+                for reranker in REGISTRY.values():
+                    result = score_case(case, shuffled, reranker, model_label=None)
+                    fh.write(json.dumps(result.__dict__) + "\n")
+
+    print(f"[run] results saved to {out_dir}")
+    return out_dir

--- a/studies/annotation_reranking/scoring.py
+++ b/studies/annotation_reranking/scoring.py
@@ -1,0 +1,44 @@
+import math
+from studies.annotation_reranking.models_data import RerankResult
+
+
+def wilson_ci(k: int, n: int, z: float = 1.96) -> tuple[float, float]:
+    if n == 0:
+        return (0.0, 1.0)
+    p = k / n
+    denom = 1 + z * z / n
+    center = (p + z * z / (2 * n)) / denom
+    half = (z * math.sqrt(p * (1 - p) / n + z * z / (4 * n * n))) / denom
+    return (max(0.0, center - half), min(1.0, center + half))
+
+
+def accuracy(results: list[RerankResult]) -> tuple[float, tuple[float, float]]:
+    scored = [r for r in results if r.is_correct is not None]
+    n = len(scored)
+    k = sum(1 for r in scored if r.is_correct)
+    return (k / n if n else 0.0, wilson_ci(k, n))
+
+
+def _binom_pmf(k: int, n: int, p: float = 0.5) -> float:
+    return math.comb(n, k) * p**k * (1 - p) ** (n - k)
+
+
+def mcnemar_exact(
+    a_correct: list[bool], b_correct: list[bool]
+) -> tuple[int, int, float]:
+    b01 = sum(1 for a, b in zip(a_correct, b_correct) if (not a) and b)
+    b10 = sum(1 for a, b in zip(a_correct, b_correct) if a and (not b))
+    n = b01 + b10
+    if n == 0:
+        return (b01, b10, 1.0)
+    x = min(b01, b10)
+    tail = sum(_binom_pmf(i, n) for i in range(0, x + 1))
+    return (b01, b10, min(1.0, 2 * tail))
+
+
+def min_discordant_for_sig(n_discordant: int, alpha: float = 0.05) -> int:
+    """Smallest all-one-direction discordant count whose two-sided exact p < alpha."""
+    for m in range(1, n_discordant + 1):
+        if 2 * _binom_pmf(0, m) < alpha:
+            return m
+    return n_discordant + 1

--- a/studies/annotation_reranking/scoring.py
+++ b/studies/annotation_reranking/scoring.py
@@ -12,8 +12,26 @@ def wilson_ci(k: int, n: int, z: float = 1.96) -> tuple[float, float]:
     return (max(0.0, center - half), min(1.0, center + half))
 
 
-def accuracy(results: list[RerankResult]) -> tuple[float, tuple[float, float]]:
+def accuracy(
+    results: list[RerankResult],
+    retrievable_only: bool = False,
+) -> tuple[float, tuple[float, float]]:
+    """Return (point estimate, Wilson 95% CI) for accuracy.
+
+    Parameters
+    ----------
+    results:
+        All RerankResult objects to consider.
+    retrievable_only:
+        When True, restrict to results whose ``regime`` is ``"retrievable"``
+        (in addition to the usual ``is_correct is not None`` filter).
+        This properly conditions accuracy on retrievability — cases where the
+        correct answer was not in the candidate window cannot be reranked
+        correctly and should be excluded from the reranker's skill estimate.
+    """
     scored = [r for r in results if r.is_correct is not None]
+    if retrievable_only:
+        scored = [r for r in scored if r.regime == "retrievable"]
     n = len(scored)
     k = sum(1 for r in scored if r.is_correct)
     return (k / n if n else 0.0, wilson_ci(k, n))

--- a/tests/studies/annotation_reranking/test_dataset.py
+++ b/tests/studies/annotation_reranking/test_dataset.py
@@ -1,0 +1,37 @@
+from studies.annotation_reranking.dataset import (
+    load_eval_cases, independent_cases, dataset_sha256,
+    TRUE_BIOMAPPER_ERRORS, REFMET_ERRORS,
+)
+
+CSV = "/home/trentleslie/Documents/Trent's Vault/Active 🎯/Work/Projects/biomapper2 - refmet ChEBI analysis/chebi_disagreements_cat.csv"
+
+def test_loads_all_172_rows():
+    cases = load_eval_cases(CSV)
+    assert len(cases) == 172
+
+def test_error_case_counts():
+    assert len(TRUE_BIOMAPPER_ERRORS) == 11
+    assert len(REFMET_ERRORS) == 2
+
+def test_independent_label_partition():
+    cases = load_eval_cases(CSV)
+    indep = independent_cases(cases)
+    # 11 biomapper-error + 2 refmet-error == 13 independently-labeled cases
+    assert len(indep) == 13
+    bm = [c for c in indep if c.label_source == "independent_biomapper_error"]
+    rm = [c for c in indep if c.label_source == "independent_refmet_error"]
+    assert len(bm) == 11 and len(rm) == 2
+    # every independent case has a concrete correct CURIE
+    assert all(c.correct_id and c.correct_id.startswith("CHEBI:") for c in indep)
+
+def test_biomapper_error_correct_id_is_refmet_node():
+    # the n=2 insight: on the 11 BM-errors, correct == RefMet's node,
+    # so rm_anchor (picks RM-bearing == RefMet node) is right by construction.
+    cases = {c.name: c for c in load_eval_cases(CSV)}
+    for name in TRUE_BIOMAPPER_ERRORS:
+        c = cases[name]
+        assert c.correct_id == f"CHEBI:{c.refmet_id}"
+
+def test_dataset_hash_is_stable_hex():
+    h = dataset_sha256(CSV)
+    assert len(h) == 64 and all(ch in "0123456789abcdef" for ch in h)

--- a/tests/studies/annotation_reranking/test_deterministic.py
+++ b/tests/studies/annotation_reranking/test_deterministic.py
@@ -1,0 +1,168 @@
+"""Tests for deterministic rerankers: top1, rm_anchor, source_weight_guard."""
+from unittest.mock import MagicMock
+
+import pytest
+
+from studies.annotation_reranking.models_data import Candidate, EvalCase
+from studies.annotation_reranking.rerankers.deterministic import (
+    RmAnchorReranker,
+    SourceWeightGuardReranker,
+    Top1Reranker,
+)
+
+
+def _c(cid, score, rm):
+    return Candidate(id=cid, score=score, name=cid, equivalent_ids=(["RM:1"] if rm else []))
+
+
+def _case(refmet_id, refmet_name=""):
+    return EvalCase(
+        name="test",
+        level="",
+        refmet_id=refmet_id,
+        refmet_name=refmet_name,
+        biomapper_ids=[],
+        biomapper_name="",
+        category="",
+        correct_id=None,
+        label_source="",
+    )
+
+
+# ---------------------------------------------------------------------------
+# top1 tests
+# ---------------------------------------------------------------------------
+
+
+def test_top1_picks_highest_score():
+    cands = [_c("CHEBI:2", 4.9, False), _c("CHEBI:9", 3.1, True)]
+    assert Top1Reranker().select(cands)[0] == "CHEBI:2"
+
+
+def test_top1_empty_returns_none():
+    assert Top1Reranker().select([])[0] is None
+
+
+def test_top1_returns_none_review_flag():
+    cands = [_c("CHEBI:2", 4.9, False)]
+    selected_id, review_flag = Top1Reranker().select(cands)
+    assert review_flag is None
+
+
+def test_top1_ignores_case():
+    cands = [_c("CHEBI:2", 4.9, False), _c("CHEBI:9", 3.1, True)]
+    case = _case("28683")
+    assert Top1Reranker().select(cands, case=case)[0] == "CHEBI:2"
+
+
+# ---------------------------------------------------------------------------
+# rm_anchor tests
+# ---------------------------------------------------------------------------
+
+
+def test_rm_anchor_prefers_rm_bearing_even_if_lower_score():
+    cands = [_c("CHEBI:2", 4.9, False), _c("CHEBI:9", 3.1, True)]
+    assert RmAnchorReranker().select(cands)[0] == "CHEBI:9"
+
+
+def test_rm_anchor_falls_back_to_top_score_when_no_rm():
+    cands = [_c("CHEBI:2", 4.9, False), _c("CHEBI:3", 3.1, False)]
+    assert RmAnchorReranker().select(cands)[0] == "CHEBI:2"
+
+
+def test_rm_anchor_breaks_ties_deterministically():
+    # two RM-bearing candidates → lowest CURIE string wins (stable, reproducible)
+    cands = [_c("CHEBI:50", 2.0, True), _c("CHEBI:27", 2.0, True)]
+    assert RmAnchorReranker().select(cands)[0] == "CHEBI:27"
+
+
+def test_rm_anchor_empty_returns_none():
+    assert RmAnchorReranker().select([])[0] is None
+
+
+def test_rm_anchor_returns_none_review_flag():
+    cands = [_c("CHEBI:2", 4.9, False), _c("CHEBI:9", 3.1, True)]
+    selected_id, review_flag = RmAnchorReranker().select(cands)
+    assert review_flag is None
+
+
+def test_rm_anchor_ignores_case():
+    cands = [_c("CHEBI:2", 4.9, False), _c("CHEBI:9", 3.1, True)]
+    case = _case("28683")
+    assert RmAnchorReranker().select(cands, case=case)[0] == "CHEBI:9"
+
+
+# ---------------------------------------------------------------------------
+# source_weight_guard tests
+# ---------------------------------------------------------------------------
+
+
+def test_swg_empty_candidates():
+    mock_fn = MagicMock()
+    r = SourceWeightGuardReranker(mock_fn)
+    result = r.select([])
+    assert result == (None, "empty_candidates")
+    mock_fn.assert_not_called()
+
+
+def test_swg_refmet_not_among_candidates():
+    """refmet_id present in case but no matching CURIE in candidates → return majority, no flag."""
+    mock_fn = MagicMock()
+    r = SourceWeightGuardReranker(mock_fn)
+    cands = [_c("CHEBI:100", 4.0, False), _c("CHEBI:200", 3.0, False)]
+    case = _case("999")  # CHEBI:999 not in candidates
+    result = r.select(cands, case=case)
+    assert result == ("CHEBI:100", None)
+    mock_fn.assert_not_called()
+
+
+def test_swg_connectivity_true_returns_refmet_no_flag():
+    """refmet present, connectivity returns True → silent refmet preference."""
+    mock_fn = MagicMock(return_value=True)
+    r = SourceWeightGuardReranker(mock_fn)
+    cands = [_c("CHEBI:100", 4.9, False), _c("CHEBI:28683", 3.1, False)]
+    case = _case("28683")  # refmet_id → CHEBI:28683
+    result = r.select(cands, case=case)
+    assert result == ("CHEBI:28683", None)
+
+
+def test_swg_connectivity_false_returns_refmet_with_flag():
+    """refmet present, connectivity returns False → flag divergent_refmet."""
+    mock_fn = MagicMock(return_value=False)
+    r = SourceWeightGuardReranker(mock_fn)
+    cands = [_c("CHEBI:100", 4.9, False), _c("CHEBI:28683", 3.1, False)]
+    case = _case("28683")
+    result = r.select(cands, case=case)
+    assert result == ("CHEBI:28683", "divergent_refmet")
+
+
+def test_swg_connectivity_none_returns_majority_with_flag():
+    """refmet present, connectivity returns None → keep majority + conflict flag."""
+    mock_fn = MagicMock(return_value=None)
+    r = SourceWeightGuardReranker(mock_fn)
+    cands = [_c("CHEBI:100", 4.9, False), _c("CHEBI:28683", 3.1, False)]
+    case = _case("28683")
+    result = r.select(cands, case=case)
+    assert result == ("CHEBI:100", "conflict_no_structure")
+
+
+def test_swg_case_none_returns_majority_no_connectivity_call():
+    """case=None → return majority, never call connectivity_fn."""
+    mock_fn = MagicMock()
+    r = SourceWeightGuardReranker(mock_fn)
+    cands = [_c("CHEBI:100", 4.9, False), _c("CHEBI:200", 3.0, False)]
+    result = r.select(cands, case=None)
+    assert result == ("CHEBI:100", None)
+    mock_fn.assert_not_called()
+
+
+def test_swg_refmet_is_majority_returns_majority_no_connectivity_call():
+    """refmet present and IS the highest-scoring → return majority, no connectivity call."""
+    mock_fn = MagicMock()
+    r = SourceWeightGuardReranker(mock_fn)
+    # CHEBI:28683 has highest score — it's both refmet and majority
+    cands = [_c("CHEBI:28683", 4.9, False), _c("CHEBI:100", 3.0, False)]
+    case = _case("28683")
+    result = r.select(cands, case=case)
+    assert result == ("CHEBI:28683", None)
+    mock_fn.assert_not_called()

--- a/tests/studies/annotation_reranking/test_deterministic.py
+++ b/tests/studies/annotation_reranking/test_deterministic.py
@@ -40,7 +40,8 @@ def test_top1_picks_highest_score():
 
 
 def test_top1_empty_returns_none():
-    assert Top1Reranker().select([])[0] is None
+    selected_id, review_flag = Top1Reranker().select([])
+    assert selected_id is None and review_flag is None
 
 
 def test_top1_returns_none_review_flag():
@@ -77,7 +78,8 @@ def test_rm_anchor_breaks_ties_deterministically():
 
 
 def test_rm_anchor_empty_returns_none():
-    assert RmAnchorReranker().select([])[0] is None
+    selected_id, review_flag = RmAnchorReranker().select([])
+    assert selected_id is None and review_flag is None
 
 
 def test_rm_anchor_returns_none_review_flag():
@@ -166,3 +168,14 @@ def test_swg_refmet_is_majority_returns_majority_no_connectivity_call():
     result = r.select(cands, case=case)
     assert result == ("CHEBI:28683", None)
     mock_fn.assert_not_called()
+
+
+def test_swg_refmet_id_with_whitespace_matches_candidate():
+    """Padded refmet_id (raw CSV field) still matches via .strip() before CURIE build."""
+    mock_fn = MagicMock(return_value=True)
+    r = SourceWeightGuardReranker(mock_fn)
+    cands = [_c("CHEBI:100", 4.9, False), _c("CHEBI:28683", 3.1, False)]
+    # refmet_id has leading/trailing whitespace — simulates raw CSV field
+    case = _case(" 28683 ")
+    result = r.select(cands, case=case)
+    assert result == ("CHEBI:28683", None)

--- a/tests/studies/annotation_reranking/test_inchikey_resolver.py
+++ b/tests/studies/annotation_reranking/test_inchikey_resolver.py
@@ -1,0 +1,142 @@
+"""Unit tests for the InChIKey first-block resolver.
+
+All network is mocked — no live calls in CI.
+Verifies layer ordering (KG → MW → PubChem), first-block extraction, caching bypass semantics,
+and the connectivity_match tri-state.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from studies.annotation_reranking.inchikey_resolver import (
+    _block_from_kg,
+    _block_from_mw,
+    _block_from_pubchem,
+    connectivity_match,
+    inchikey_block,
+)
+
+_BLOCK = "ABCDEFGHIJKLMN"
+_FULL_IK = "ABCDEFGHIJKLMN-OPQRSTUVWX-Y"
+
+
+class TestLayerOrdering:
+    def test_kg_hit_skips_mw_and_pubchem(self):
+        """KG returning a block must short-circuit MW and PubChem (never called)."""
+        with (
+            patch(
+                "studies.annotation_reranking.inchikey_resolver._block_from_kg",
+                return_value=_BLOCK,
+            ) as mock_kg,
+            patch(
+                "studies.annotation_reranking.inchikey_resolver._block_from_mw",
+                return_value=MagicMock(),
+            ) as mock_mw,
+            patch(
+                "studies.annotation_reranking.inchikey_resolver._block_from_pubchem",
+                return_value=MagicMock(),
+            ) as mock_pc,
+        ):
+            result = inchikey_block.__wrapped__("CHEBI:1", "x")
+            assert result == _BLOCK
+            mock_kg.assert_called_once_with("CHEBI:1")
+            mock_mw.assert_not_called()
+            mock_pc.assert_not_called()
+
+    def test_kg_miss_falls_through_to_mw(self):
+        """KG miss (None) must call MW; PubChem must NOT be called when MW succeeds."""
+        with (
+            patch(
+                "studies.annotation_reranking.inchikey_resolver._block_from_kg",
+                return_value=None,
+            ),
+            patch(
+                "studies.annotation_reranking.inchikey_resolver._block_from_mw",
+                return_value=_BLOCK,
+            ) as mock_mw,
+            patch(
+                "studies.annotation_reranking.inchikey_resolver._block_from_pubchem",
+                return_value=MagicMock(),
+            ) as mock_pc,
+        ):
+            result = inchikey_block.__wrapped__("CHEBI:1", "glucose")
+            assert result == _BLOCK
+            mock_mw.assert_called_once_with("glucose")
+            mock_pc.assert_not_called()
+
+    def test_mw_miss_falls_through_to_pubchem(self):
+        """Both KG and MW miss (None) — result must come from PubChem."""
+        with (
+            patch(
+                "studies.annotation_reranking.inchikey_resolver._block_from_kg",
+                return_value=None,
+            ),
+            patch(
+                "studies.annotation_reranking.inchikey_resolver._block_from_mw",
+                return_value=None,
+            ),
+            patch(
+                "studies.annotation_reranking.inchikey_resolver._block_from_pubchem",
+                return_value=_BLOCK,
+            ) as mock_pc,
+        ):
+            result = inchikey_block.__wrapped__("CHEBI:1", "glucose")
+            assert result == _BLOCK
+            mock_pc.assert_called_once_with("glucose")
+
+    def test_all_miss_returns_none(self):
+        """All three layers returning None → inchikey_block returns None."""
+        with (
+            patch(
+                "studies.annotation_reranking.inchikey_resolver._block_from_kg",
+                return_value=None,
+            ),
+            patch(
+                "studies.annotation_reranking.inchikey_resolver._block_from_mw",
+                return_value=None,
+            ),
+            patch(
+                "studies.annotation_reranking.inchikey_resolver._block_from_pubchem",
+                return_value=None,
+            ),
+        ):
+            result = inchikey_block.__wrapped__("CHEBI:99", "unknown-compound")
+            assert result is None
+
+
+class TestFirstBlockExtraction:
+    def test_first_block_extraction(self):
+        """_block_from_kg must split on '-' and return the connectivity block only."""
+        full_ik = "ABCDEFGHIJKLMN-OPQRSTUVWX-Y"
+        with patch(
+            "studies.annotation_reranking.inchikey_resolver.Linker.get_equivalent_ids",
+            return_value={"CHEBI:1": {"INCHIKEY": [full_ik]}},
+        ):
+            result = _block_from_kg("CHEBI:1")
+        assert result == "ABCDEFGHIJKLMN"
+
+
+class TestConnectivityMatch:
+    def test_connectivity_match_true_false_none(self):
+        """connectivity_match tri-state: True (same block), False (different), None (unresolvable)."""
+        side_effects = {
+            ("CHEBI:A", "aspirin"): "BSYNRYMUTXBXSQ",
+            ("CHEBI:B", "aspirin-b"): "BSYNRYMUTXBXSQ",
+            ("CHEBI:C", "ibuprofen"): "HEFNNWSXXWATRW",
+            ("CHEBI:D", "unknown"): None,
+        }
+
+        def fake_block(node_id, name):
+            return side_effects.get((node_id, name))
+
+        with patch(
+            "studies.annotation_reranking.inchikey_resolver.inchikey_block",
+            side_effect=fake_block,
+        ):
+            # same block → True
+            assert connectivity_match("CHEBI:A", "aspirin", "CHEBI:B", "aspirin-b") is True
+            # different blocks → False
+            assert connectivity_match("CHEBI:A", "aspirin", "CHEBI:C", "ibuprofen") is False
+            # one unresolvable → None
+            assert connectivity_match("CHEBI:A", "aspirin", "CHEBI:D", "unknown") is None

--- a/tests/studies/annotation_reranking/test_inchikey_resolver.py
+++ b/tests/studies/annotation_reranking/test_inchikey_resolver.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from studies.annotation_reranking import inchikey_resolver
 from studies.annotation_reranking.inchikey_resolver import (
     _block_from_kg,
     _block_from_mw,
@@ -19,6 +20,12 @@ from studies.annotation_reranking.inchikey_resolver import (
 
 _BLOCK = "ABCDEFGHIJKLMN"
 _FULL_IK = "ABCDEFGHIJKLMN-OPQRSTUVWX-Y"
+
+
+@pytest.fixture(autouse=True)
+def _clear_inchikey_cache():
+    inchikey_resolver.inchikey_block.cache_clear()
+    yield
 
 
 class TestLayerOrdering:

--- a/tests/studies/annotation_reranking/test_labels.py
+++ b/tests/studies/annotation_reranking/test_labels.py
@@ -1,0 +1,368 @@
+"""Tests for studies/annotation_reranking/labels.py — Task 10.
+
+TDD: tests written first (RED), then labels.py implemented (GREEN).
+All network-facing functions are mocked — NO live calls in CI.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch, call
+
+import pytest
+
+from studies.annotation_reranking.models_data import EvalCase
+from studies.annotation_reranking.labels import derive_label, derive_labels, name_block
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _case(
+    name: str = "test_metabolite",
+    refmet_id: str = "100",
+    refmet_name: str = "RefMetName",
+    biomapper_ids: list[str] | None = None,
+    biomapper_name: str = "BioMapperName",
+    correct_id: str | None = None,
+    label_source: str = "refmet_agreement",
+    inchikey_block_correct: str | None = None,
+) -> EvalCase:
+    return EvalCase(
+        name=name,
+        level="MS1",
+        refmet_id=refmet_id,
+        refmet_name=refmet_name,
+        biomapper_ids=biomapper_ids if biomapper_ids is not None else ["CHEBI:200"],
+        biomapper_name=biomapper_name,
+        category="metabolite",
+        correct_id=correct_id,
+        label_source=label_source,
+        inchikey_block_correct=inchikey_block_correct,
+    )
+
+
+# Block string constants used throughout tests.
+BLOCK_REF = "AAAAAAAAAAAAAAA"   # analyte's true connectivity block
+BLOCK_RM  = "BBBBBBBBBBBBBBB"   # RefMet node block
+BLOCK_BIO = "CCCCCCCCCCCCCCC"   # BioMapper node block
+BLOCK_SAME = "XXXXXXXXXXXXXZ0"  # shared block (rb == bb)
+
+
+# ---------------------------------------------------------------------------
+# Rule 1: hand-triaged wins
+# ---------------------------------------------------------------------------
+
+class TestHandTriagedWins:
+    def test_biomapper_error_case_returned_unchanged(self):
+        """Hand-triaged case (label_source='independent_biomapper_error') must not be modified."""
+        case = _case(
+            correct_id="CHEBI:999",
+            label_source="independent_biomapper_error",
+        )
+        node_fn = lambda nid, nm: BLOCK_RM if "CHEBI:100" in nid else BLOCK_BIO
+        name_fn = lambda nm: BLOCK_REF
+
+        cid, src, ik = derive_label(case, name_block_fn=name_fn, node_block_fn=node_fn)
+
+        assert cid == "CHEBI:999"
+        assert src == "independent_biomapper_error"
+        assert ik is None
+
+    def test_refmet_error_case_returned_unchanged(self):
+        """label_source='independent_refmet_error' → returned unchanged."""
+        case = _case(
+            correct_id="CHEBI:200",
+            label_source="independent_refmet_error",
+        )
+        node_fn = lambda nid, nm: BLOCK_RM
+        name_fn = lambda nm: BLOCK_REF
+
+        cid, src, ik = derive_label(case, name_block_fn=name_fn, node_block_fn=node_fn)
+
+        assert cid == "CHEBI:200"
+        assert src == "independent_refmet_error"
+        assert ik is None
+
+
+# ---------------------------------------------------------------------------
+# Rule 2: same connectivity → expert_needed
+# ---------------------------------------------------------------------------
+
+class TestSameConnectivity:
+    def test_same_rb_and_bio_gives_expert_needed(self):
+        """rb == bb → (None, 'expert_needed', ref), even if ref differs."""
+        case = _case(refmet_id="100", biomapper_ids=["CHEBI:200"])
+        # rb and bb are the same; ref is different.
+        node_fn = lambda nid, nm: BLOCK_SAME  # both refmet and bio get same block
+        name_fn = lambda nm: BLOCK_REF        # ref differs from BLOCK_SAME
+
+        cid, src, ik = derive_label(case, name_block_fn=name_fn, node_block_fn=node_fn)
+
+        assert cid is None
+        assert src == "expert_needed"
+        assert ik == BLOCK_REF  # ref is still resolved
+
+    def test_same_connectivity_takes_priority_over_rule_3(self):
+        """Rule 2 fires even when ref == rb (which would satisfy rule 3 refmet pick).
+
+        This is the critical priority check: rb==bb==ref would look like a
+        valid refmet pick under rule 3, but rule 2 must fire first.
+        """
+        case = _case(refmet_id="100", biomapper_ids=["CHEBI:200"])
+        # All three blocks are identical — rule 3 'rb==ref' would fire if rule 2 didn't.
+        ALL_SAME = "ZZZZZZZZZZZZZZ1"
+        node_fn = lambda nid, nm: ALL_SAME
+        name_fn = lambda nm: ALL_SAME
+
+        cid, src, ik = derive_label(case, name_block_fn=name_fn, node_block_fn=node_fn)
+
+        assert src == "expert_needed", "Rule 2 must override rule 3 when rb==bb"
+
+    def test_rb_none_skips_rule_2(self):
+        """If rb is None, rule 2 is skipped regardless of bio blocks."""
+        case = _case(refmet_id="100", biomapper_ids=["CHEBI:200"])
+        node_fn = lambda nid, nm: None  # rb=None, bio=None
+        name_fn = lambda nm: None       # ref also None
+
+        cid, src, ik = derive_label(case, name_block_fn=name_fn, node_block_fn=node_fn)
+
+        # Falls through to rule 4.
+        assert src == "refmet_agreement"
+        assert ik is None
+
+
+# ---------------------------------------------------------------------------
+# Rule 3a: ref == rb only → refmet pick
+# ---------------------------------------------------------------------------
+
+class TestRefmetPick:
+    def test_ref_matches_rb_not_bio_gives_refmet_curie(self):
+        """ref==rb and no bio bb==ref → (refmet_curie, 'inchikey_connectivity', ref)."""
+        case = _case(refmet_id="100", biomapper_ids=["CHEBI:200"])
+        # rb == ref; bio differs
+        node_fn = lambda nid, nm: BLOCK_REF if "CHEBI:100" in nid else BLOCK_BIO
+        name_fn = lambda nm: BLOCK_REF
+
+        cid, src, ik = derive_label(case, name_block_fn=name_fn, node_block_fn=node_fn)
+
+        assert cid == "CHEBI:100"
+        assert src == "inchikey_connectivity"
+        assert ik == BLOCK_REF
+
+
+# ---------------------------------------------------------------------------
+# Rule 3b: ref == one bio bb only → bio pick
+# ---------------------------------------------------------------------------
+
+class TestBioMapperPick:
+    def test_ref_matches_one_bio_gives_bio_id(self):
+        """ref==bb for exactly one bio and rb!=ref → (that_bid, 'inchikey_connectivity', ref)."""
+        case = _case(refmet_id="100", biomapper_ids=["CHEBI:200"])
+        # rb differs from ref; bio matches ref
+        node_fn = lambda nid, nm: BLOCK_RM if "CHEBI:100" in nid else BLOCK_REF
+        name_fn = lambda nm: BLOCK_REF
+
+        cid, src, ik = derive_label(case, name_block_fn=name_fn, node_block_fn=node_fn)
+
+        assert cid == "CHEBI:200"
+        assert src == "inchikey_connectivity"
+        assert ik == BLOCK_REF
+
+
+# ---------------------------------------------------------------------------
+# Rule 3c: ref matches neither → refmet_agreement
+# ---------------------------------------------------------------------------
+
+class TestAmbiguous:
+    def test_ref_matches_neither_gives_refmet_agreement(self):
+        """ref differs from both rb and all bio blocks → (None, 'refmet_agreement', ref)."""
+        case = _case(refmet_id="100", biomapper_ids=["CHEBI:200"])
+        node_fn = lambda nid, nm: BLOCK_RM if "CHEBI:100" in nid else BLOCK_BIO
+        name_fn = lambda nm: BLOCK_REF  # ref is a third distinct block
+
+        cid, src, ik = derive_label(case, name_block_fn=name_fn, node_block_fn=node_fn)
+
+        assert cid is None
+        assert src == "refmet_agreement"
+        assert ik == BLOCK_REF
+
+
+# ---------------------------------------------------------------------------
+# Rule 4: ref is None → refmet_agreement with ik=None
+# ---------------------------------------------------------------------------
+
+class TestRefNone:
+    def test_ref_none_not_same_connectivity_gives_refmet_agreement_none(self):
+        """ref=None and rb!=bio → (None, 'refmet_agreement', None)."""
+        case = _case(refmet_id="100", biomapper_ids=["CHEBI:200"])
+        node_fn = lambda nid, nm: BLOCK_RM if "CHEBI:100" in nid else BLOCK_BIO
+        name_fn = lambda nm: None  # cannot resolve name
+
+        cid, src, ik = derive_label(case, name_block_fn=name_fn, node_block_fn=node_fn)
+
+        assert cid is None
+        assert src == "refmet_agreement"
+        assert ik is None
+
+
+# ---------------------------------------------------------------------------
+# name_block layer order: MW tried before PubChem
+# ---------------------------------------------------------------------------
+
+class TestNameBlockLayerOrder:
+    def test_mw_tried_before_pubchem(self):
+        """When MW returns None, PubChem is tried; result is the PubChem block."""
+        with (
+            patch(
+                "studies.annotation_reranking.labels._block_from_mw",
+                return_value=None,
+            ) as mock_mw,
+            patch(
+                "studies.annotation_reranking.labels._block_from_pubchem",
+                return_value="ABCDEFGHIJKLMNO",
+            ) as mock_pc,
+        ):
+            # Clear the lru_cache so our patches are actually called.
+            from studies.annotation_reranking.labels import name_block as nb
+            nb.cache_clear()
+
+            result = nb("test_compound_x")
+
+        assert result == "ABCDEFGHIJKLMNO"
+        mock_mw.assert_called_once_with("test_compound_x")
+        mock_pc.assert_called_once_with("test_compound_x")
+
+    def test_mw_wins_when_returns_block(self):
+        """When MW returns a block, PubChem is never called."""
+        with (
+            patch(
+                "studies.annotation_reranking.labels._block_from_mw",
+                return_value="MWBLOCKXXXXXXXX",
+            ) as mock_mw,
+            patch(
+                "studies.annotation_reranking.labels._block_from_pubchem",
+                return_value="PUBCHEMBLOCK1234",
+            ) as mock_pc,
+        ):
+            from studies.annotation_reranking.labels import name_block as nb
+            nb.cache_clear()
+
+            result = nb("some_metabolite")
+
+        assert result == "MWBLOCKXXXXXXXX"
+        mock_mw.assert_called_once_with("some_metabolite")
+        mock_pc.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# derive_labels — bulk mutation
+# ---------------------------------------------------------------------------
+
+class TestDeriveLabels:
+    def test_mutates_and_returns_cases(self):
+        """derive_labels over a 2-case list mutates each case and returns the list."""
+        case1 = _case(
+            name="metabolite_a",
+            refmet_id="100",
+            biomapper_ids=["CHEBI:200"],
+            label_source="refmet_agreement",
+        )
+        case2 = _case(
+            name="metabolite_b",
+            refmet_id="300",
+            biomapper_ids=["CHEBI:400"],
+            label_source="refmet_agreement",
+        )
+
+        # case1: rb==ref → refmet pick
+        # case2: bio bb==ref → bio pick
+        def node_fn(nid: str, nm: str) -> str | None:
+            if "CHEBI:100" in nid or "CHEBI:300" in nid:
+                return BLOCK_RM
+            if "CHEBI:200" in nid:
+                return BLOCK_REF   # bio of case1 differs from ref
+            if "CHEBI:400" in nid:
+                return BLOCK_REF   # bio of case2 matches ref
+            return BLOCK_BIO
+
+        def name_fn(name: str) -> str | None:
+            if name == "metabolite_a":
+                return BLOCK_RM   # rb==ref → refmet pick for case1
+            if name == "metabolite_b":
+                return BLOCK_REF  # bio of case2 matches ref → bio pick for case2
+            return None
+
+        with patch(
+            "studies.annotation_reranking.labels.inchikey_block",
+            side_effect=node_fn,
+        ):
+            result = derive_labels(
+                [case1, case2],
+            )
+            # Provide name_block_fn explicitly to bypass cache
+            # Re-run with explicit injection instead.
+
+        # Actually call directly with injected fns to avoid cache complications.
+        case1 = _case(
+            name="metabolite_a",
+            refmet_id="100",
+            biomapper_ids=["CHEBI:200"],
+            label_source="refmet_agreement",
+        )
+        case2 = _case(
+            name="metabolite_b",
+            refmet_id="300",
+            biomapper_ids=["CHEBI:400"],
+            label_source="refmet_agreement",
+        )
+
+        for case in [case1, case2]:
+            cid, src, ik = derive_label(
+                case,
+                name_block_fn=name_fn,
+                node_block_fn=node_fn,
+            )
+            case.correct_id = cid
+            case.label_source = src
+            case.inchikey_block_correct = ik
+
+        # case1: rb==BLOCK_RM, ref==BLOCK_RM → refmet pick
+        assert case1.correct_id == "CHEBI:100"
+        assert case1.label_source == "inchikey_connectivity"
+        assert case1.inchikey_block_correct == BLOCK_RM
+
+        # case2: rb==BLOCK_RM, bio==BLOCK_REF, ref==BLOCK_REF → bio pick
+        assert case2.correct_id == "CHEBI:400"
+        assert case2.label_source == "inchikey_connectivity"
+        assert case2.inchikey_block_correct == BLOCK_REF
+
+    def test_derive_labels_returns_same_list_object(self):
+        """derive_labels returns the same list (not a copy)."""
+        cases = [_case(label_source="refmet_agreement")]
+        node_fn = lambda nid, nm: None
+        name_fn = lambda nm: None
+
+        # Patch the default functions so no network calls occur.
+        with (
+            patch("studies.annotation_reranking.labels.inchikey_block", side_effect=node_fn),
+            patch("studies.annotation_reranking.labels.name_block", side_effect=name_fn),
+        ):
+            result = derive_labels(cases)
+
+        assert result is cases
+
+    def test_derive_labels_hand_triaged_unchanged(self):
+        """derive_labels must not overwrite hand-triaged cases."""
+        case = _case(correct_id="CHEBI:777", label_source="independent_biomapper_error")
+        node_fn = lambda nid, nm: BLOCK_BIO
+        name_fn = lambda nm: BLOCK_REF
+
+        with (
+            patch("studies.annotation_reranking.labels.inchikey_block", side_effect=node_fn),
+            patch("studies.annotation_reranking.labels.name_block", side_effect=name_fn),
+        ):
+            derive_labels([case])
+
+        assert case.correct_id == "CHEBI:777"
+        assert case.label_source == "independent_biomapper_error"
+        assert case.inchikey_block_correct is None

--- a/tests/studies/annotation_reranking/test_labels.py
+++ b/tests/studies/annotation_reranking/test_labels.py
@@ -260,7 +260,13 @@ class TestNameBlockLayerOrder:
 
 class TestDeriveLabels:
     def test_mutates_and_returns_cases(self):
-        """derive_labels over a 2-case list mutates each case and returns the list."""
+        """derive_labels over a 2-case list mutates each case in-place and returns the list.
+
+        derive_labels calls derive_label with no injected functions, so it uses the
+        module-level name_block (lru_cache-wrapped).  We patch _block_from_mw (the first
+        layer inside name_block) in the labels namespace and clear the cache before the
+        test so the patches are exercised by the real name_block call chain.
+        """
         case1 = _case(
             name="metabolite_a",
             refmet_id="100",
@@ -273,65 +279,46 @@ class TestDeriveLabels:
             biomapper_ids=["CHEBI:400"],
             label_source="refmet_agreement",
         )
+        cases = [case1, case2]
 
-        # case1: rb==ref → refmet pick
-        # case2: bio bb==ref → bio pick
+        # case1: rb==BLOCK_RM, ref(name)==BLOCK_RM → rb==ref, no bio match → refmet pick
+        # case2: rb==BLOCK_RM, ref(name)==BLOCK_REF, bio(CHEBI:400)==BLOCK_REF → bio pick
         def node_fn(nid: str, nm: str) -> str | None:
             if "CHEBI:100" in nid or "CHEBI:300" in nid:
-                return BLOCK_RM
+                return BLOCK_RM   # refmet nodes for both cases
             if "CHEBI:200" in nid:
-                return BLOCK_REF   # bio of case1 differs from ref
+                return BLOCK_BIO  # bio of case1 differs from ref
             if "CHEBI:400" in nid:
-                return BLOCK_REF   # bio of case2 matches ref
-            return BLOCK_BIO
-
-        def name_fn(name: str) -> str | None:
-            if name == "metabolite_a":
-                return BLOCK_RM   # rb==ref → refmet pick for case1
-            if name == "metabolite_b":
-                return BLOCK_REF  # bio of case2 matches ref → bio pick for case2
+                return BLOCK_REF  # bio of case2 matches ref
             return None
 
-        with patch(
-            "studies.annotation_reranking.labels.inchikey_block",
-            side_effect=node_fn,
+        def mw_name_fn(name: str) -> str | None:
+            """Simulate the MW layer of name_block: returns the block for known names."""
+            if name == "metabolite_a":
+                return BLOCK_RM   # ref==rb → refmet pick for case1
+            if name == "metabolite_b":
+                return BLOCK_REF  # ref==bio bb → bio pick for case2
+            return None
+
+        # Clear the lru_cache so our _block_from_mw patch is actually called.
+        name_block.cache_clear()
+
+        with (
+            patch("studies.annotation_reranking.labels.inchikey_block", side_effect=node_fn),
+            patch("studies.annotation_reranking.labels._block_from_mw", side_effect=mw_name_fn),
+            patch("studies.annotation_reranking.labels._block_from_pubchem", return_value=None),
         ):
-            result = derive_labels(
-                [case1, case2],
-            )
-            # Provide name_block_fn explicitly to bypass cache
-            # Re-run with explicit injection instead.
+            result = derive_labels(cases)
 
-        # Actually call directly with injected fns to avoid cache complications.
-        case1 = _case(
-            name="metabolite_a",
-            refmet_id="100",
-            biomapper_ids=["CHEBI:200"],
-            label_source="refmet_agreement",
-        )
-        case2 = _case(
-            name="metabolite_b",
-            refmet_id="300",
-            biomapper_ids=["CHEBI:400"],
-            label_source="refmet_agreement",
-        )
+        # (a) returns the same list object
+        assert result is cases
 
-        for case in [case1, case2]:
-            cid, src, ik = derive_label(
-                case,
-                name_block_fn=name_fn,
-                node_block_fn=node_fn,
-            )
-            case.correct_id = cid
-            case.label_source = src
-            case.inchikey_block_correct = ik
-
-        # case1: rb==BLOCK_RM, ref==BLOCK_RM → refmet pick
+        # (b) case1: rb==BLOCK_RM, ref==BLOCK_RM → refmet pick
         assert case1.correct_id == "CHEBI:100"
         assert case1.label_source == "inchikey_connectivity"
         assert case1.inchikey_block_correct == BLOCK_RM
 
-        # case2: rb==BLOCK_RM, bio==BLOCK_REF, ref==BLOCK_REF → bio pick
+        # (b) case2: rb==BLOCK_RM, bio==BLOCK_REF, ref==BLOCK_REF → bio pick
         assert case2.correct_id == "CHEBI:400"
         assert case2.label_source == "inchikey_connectivity"
         assert case2.inchikey_block_correct == BLOCK_REF

--- a/tests/studies/annotation_reranking/test_llm.py
+++ b/tests/studies/annotation_reranking/test_llm.py
@@ -8,11 +8,12 @@ from studies.annotation_reranking.models_data import Candidate
 
 
 def _c(cid, rm):
+    # Two RM entries when rm=True so blinding tests cover exhaustive removal.
     return Candidate(
         id=cid,
         score=1.0,
         name=cid,
-        equivalent_ids=(["RM:9", "HMDB:1"] if rm else ["HMDB:1"]),
+        equivalent_ids=(["RM:9", "RM:10", "HMDB:1"] if rm else ["HMDB:1"]),
     )
 
 
@@ -23,14 +24,16 @@ def _c(cid, rm):
 
 def test_blind_strips_rm_ids_from_prompt():
     cands = [_c("CHEBI:1", True), _c("CHEBI:2", False)]
-    assert "RM:9" in build_prompt(cands, blind_rm=False)
-    assert "RM:9" not in build_prompt(cands, blind_rm=True)
+    # Exhaustive check: no RM: prefix of any kind survives blinding.
+    assert "RM:" in build_prompt(cands, blind_rm=False)
+    assert "RM:" not in build_prompt(cands, blind_rm=True)
 
 
 def test_non_blind_includes_rm_ids():
     cands = [_c("CHEBI:1", True)]
     prompt = build_prompt(cands, blind_rm=False)
     assert "RM:9" in prompt
+    assert "RM:10" in prompt
     assert "HMDB:1" in prompt
 
 
@@ -75,6 +78,8 @@ def test_parse_rejects_empty_text():
 
 def test_llm_reranker_uses_injected_call_fn():
     cands = [_c("CHEBI:1", True), _c("CHEBI:2", False)]
+    # stub returns a 3-tuple for test bookkeeping only; call_fn contract is
+    # (model_name: str, prompt: str) -> str, so we pass [0] (the text) to LlmReranker.
     stub = lambda model, prompt: ("CHEBI:2", 0.0, 0.0)  # (text, cost, latency)
     r = LlmReranker("sonnet", call_fn=lambda m, p: stub(m, p)[0], blind_rm=True)
     assert r.name == "llm:sonnet/blind"

--- a/tests/studies/annotation_reranking/test_llm.py
+++ b/tests/studies/annotation_reranking/test_llm.py
@@ -1,0 +1,136 @@
+"""Tests for LLM reranker: build_prompt (RM-blinding), parse_selection, LlmReranker.
+
+Revision 2026-07-08: select() returns (selected_id, review_flag) tuple;
+LlmReranker always returns (selected_id, None).
+"""
+from studies.annotation_reranking.rerankers.llm import build_prompt, parse_selection, LlmReranker
+from studies.annotation_reranking.models_data import Candidate
+
+
+def _c(cid, rm):
+    return Candidate(
+        id=cid,
+        score=1.0,
+        name=cid,
+        equivalent_ids=(["RM:9", "HMDB:1"] if rm else ["HMDB:1"]),
+    )
+
+
+# ---------------------------------------------------------------------------
+# build_prompt tests
+# ---------------------------------------------------------------------------
+
+
+def test_blind_strips_rm_ids_from_prompt():
+    cands = [_c("CHEBI:1", True), _c("CHEBI:2", False)]
+    assert "RM:9" in build_prompt(cands, blind_rm=False)
+    assert "RM:9" not in build_prompt(cands, blind_rm=True)
+
+
+def test_non_blind_includes_rm_ids():
+    cands = [_c("CHEBI:1", True)]
+    prompt = build_prompt(cands, blind_rm=False)
+    assert "RM:9" in prompt
+    assert "HMDB:1" in prompt
+
+
+def test_prompt_includes_candidate_ids():
+    cands = [_c("CHEBI:1", True), _c("CHEBI:2", False)]
+    prompt = build_prompt(cands, blind_rm=False)
+    assert "CHEBI:1" in prompt
+    assert "CHEBI:2" in prompt
+
+
+# ---------------------------------------------------------------------------
+# parse_selection tests
+# ---------------------------------------------------------------------------
+
+
+def test_parse_accepts_in_list_curie():
+    cands = [_c("CHEBI:1", True), _c("CHEBI:2", False)]
+    assert parse_selection("I choose CHEBI:2 because ...", cands) == "CHEBI:2"
+
+
+def test_parse_accepts_first_matching_curie():
+    cands = [_c("CHEBI:1", True), _c("CHEBI:2", False)]
+    # both in prompt — should return whichever appears first in text
+    assert parse_selection("CHEBI:1 is better than CHEBI:2", cands) == "CHEBI:1"
+
+
+def test_parse_rejects_off_list_or_garbage():
+    cands = [_c("CHEBI:1", True)]
+    assert parse_selection("CHEBI:99999", cands) is None      # hallucinated / off-list
+    assert parse_selection("none of these", cands) is None
+
+
+def test_parse_rejects_empty_text():
+    cands = [_c("CHEBI:1", True)]
+    assert parse_selection("", cands) is None
+
+
+# ---------------------------------------------------------------------------
+# LlmReranker tests (tuple protocol: (selected_id, None))
+# ---------------------------------------------------------------------------
+
+
+def test_llm_reranker_uses_injected_call_fn():
+    cands = [_c("CHEBI:1", True), _c("CHEBI:2", False)]
+    stub = lambda model, prompt: ("CHEBI:2", 0.0, 0.0)  # (text, cost, latency)
+    r = LlmReranker("sonnet", call_fn=lambda m, p: stub(m, p)[0], blind_rm=True)
+    assert r.name == "llm:sonnet/blind"
+    assert r.select(cands) == ("CHEBI:2", None)
+
+
+def test_llm_reranker_name_non_blind():
+    r = LlmReranker("opus", call_fn=lambda m, p: "", blind_rm=False)
+    assert r.name == "llm:opus"
+
+
+def test_llm_reranker_empty_candidates_returns_none_tuple():
+    r = LlmReranker("sonnet", call_fn=lambda m, p: "CHEBI:1", blind_rm=False)
+    assert r.select([]) == (None, None)
+
+
+def test_llm_reranker_review_flag_always_none():
+    """LLM rerankers never emit a review flag per Revision 2026-07-08."""
+    cands = [_c("CHEBI:1", True), _c("CHEBI:2", False)]
+    r = LlmReranker("sonnet", call_fn=lambda m, p: "CHEBI:1", blind_rm=False)
+    selected_id, review_flag = r.select(cands)
+    assert review_flag is None
+
+
+def test_llm_reranker_off_list_response_returns_none_id():
+    """If model returns an off-list CURIE, selected_id is None (parse returns None)."""
+    cands = [_c("CHEBI:1", True)]
+    r = LlmReranker("sonnet", call_fn=lambda m, p: "CHEBI:99999", blind_rm=False)
+    selected_id, review_flag = r.select(cands)
+    assert selected_id is None
+    assert review_flag is None
+
+
+def test_llm_reranker_blind_passes_blind_rm_to_prompt():
+    """Verify that blind reranker actually strips RM: from the prompt passed to call_fn."""
+    captured = {}
+
+    def capturing_fn(model, prompt):
+        captured["prompt"] = prompt
+        return "CHEBI:1"
+
+    cands = [_c("CHEBI:1", True)]
+    r = LlmReranker("sonnet", call_fn=capturing_fn, blind_rm=True)
+    r.select(cands)
+    assert "RM:9" not in captured["prompt"]
+
+
+def test_llm_reranker_select_accepts_case_kwarg():
+    """select() accepts optional case= kwarg without error (protocol compatibility)."""
+    from studies.annotation_reranking.models_data import EvalCase
+    cands = [_c("CHEBI:1", True)]
+    r = LlmReranker("sonnet", call_fn=lambda m, p: "CHEBI:1", blind_rm=False)
+    case = EvalCase(
+        name="test", level="", refmet_id="1", refmet_name="",
+        biomapper_ids=[], biomapper_name="", category="",
+        correct_id=None, label_source="",
+    )
+    result = r.select(cands, case=case)
+    assert result == ("CHEBI:1", None)

--- a/tests/studies/annotation_reranking/test_model_call.py
+++ b/tests/studies/annotation_reranking/test_model_call.py
@@ -1,0 +1,65 @@
+"""Tests for the unified model-call layer + roster (Task 6).
+
+Mocks all SDK clients so no real API calls are made and no API key is required.
+"""
+from unittest.mock import patch, MagicMock
+
+from studies.annotation_reranking import model_call
+from studies.annotation_reranking.model_call import ModelCfg
+
+
+def test_roster_has_full_matrix_providers():
+    labels = {c.label for c in model_call.ROSTER}
+    assert {"opus", "sonnet"} <= labels
+    assert any(c.provider == "openai" for c in model_call.ROSTER)      # GPT-5.5-class
+    assert any(c.provider == "openrouter" for c in model_call.ROSTER)  # small open
+    assert all(c.quant_note for c in model_call.ROSTER if c.provider == "openrouter")
+
+
+def test_call_model_openrouter_returns_text_cost_latency():
+    cfg = ModelCfg("qwen3-8b", "openrouter", "qwen/qwen3-8b", "OpenRouter fp8, NOT local Q4")
+    fake = {"text": "CHEBI:2", "cost": 0.0004}
+    with patch.object(model_call, "_call_openrouter", return_value=fake):
+        text, cost, latency = model_call.call_model(cfg, "prompt", seed=0)
+    assert text == "CHEBI:2" and cost == 0.0004 and latency >= 0.0
+
+
+def test_call_model_anthropic_returns_text_cost_latency():
+    cfg = ModelCfg("sonnet", "anthropic", "claude-sonnet-4-6")
+    fake = {"text": "HMDB0001", "cost": 0.0}
+    with patch.object(model_call, "_call_anthropic", return_value=fake):
+        text, cost, latency = model_call.call_model(cfg, "map this", seed=0)
+    assert text == "HMDB0001" and cost == 0.0 and latency >= 0.0
+
+
+def test_call_model_openai_returns_text_cost_latency():
+    cfg = ModelCfg("gpt-5.5", "openai", "PIN_AT_RUNTIME")
+    fake = {"text": "CHEBI:99", "cost": 0.0}
+    with patch.object(model_call, "_call_openai", return_value=fake):
+        text, cost, latency = model_call.call_model(cfg, "map this", seed=0)
+    assert text == "CHEBI:99" and cost == 0.0 and latency >= 0.0
+
+
+def test_import_does_not_read_key_or_hit_network():
+    """Importing model_call must not read the key file or open network connections.
+
+    Verified by the fact that the module imported at the top of this file
+    without any API key available in the test environment (and tests pass).
+    The key is read lazily inside _load_openrouter_key(), which is only called
+    from _call_openrouter(), and only when not already in the environment.
+    """
+    # If we got this far without errors, the import was clean.
+    assert model_call.ROSTER is not None
+
+
+def test_modelcfg_defaults():
+    cfg = ModelCfg("opus", "anthropic", "claude-opus-4-8")
+    assert cfg.quant_note == ""
+
+
+def test_roster_openrouter_quant_notes():
+    for cfg in model_call.ROSTER:
+        if cfg.provider == "openrouter":
+            assert "NOT local" in cfg.quant_note, (
+                f"{cfg.label} quant_note should clarify NOT local Q4: {cfg.quant_note!r}"
+            )

--- a/tests/studies/annotation_reranking/test_phase0.py
+++ b/tests/studies/annotation_reranking/test_phase0.py
@@ -1,7 +1,8 @@
 """Tests for phase0.py — Phase 0 decision gate.
 
-All network calls are mocked. We patch fetch_candidates and load_eval_cases
-so no live Kestrel / MW / PubChem traffic occurs in CI.
+All network calls are mocked. We patch fetch_candidates, load_eval_cases,
+dataset_sha256, AND the source_weight_guard in REGISTRY so no live
+Kestrel / MW / PubChem traffic occurs in CI.
 """
 import json
 import os
@@ -78,6 +79,26 @@ def _import_run_phase0():
     return run_phase0
 
 
+def _make_fake_swg(selected_id: str = "CHEBI:100", review_flag: str = "divergent_refmet") -> MagicMock:
+    """Return a MagicMock that stands in for the source_weight_guard reranker.
+
+    select() returns (selected_id, review_flag) so the caller never reaches
+    connectivity_match / get_equivalent_ids / MW / PubChem.
+    """
+    fake = MagicMock()
+    fake.select.return_value = (selected_id, review_flag)
+    return fake
+
+
+def _swg_patch(fake_swg: MagicMock):
+    """patch.dict context manager that replaces REGISTRY['source_weight_guard']."""
+    return patch.dict(
+        "studies.annotation_reranking.phase0.REGISTRY",
+        {"source_weight_guard": fake_swg},
+        clear=False,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
@@ -86,6 +107,7 @@ def _import_run_phase0():
 def test_run_phase0_summary_keys(tmp_path):
     """run_phase0 returns a dict with all required summary keys."""
     run_phase0 = _import_run_phase0()
+    fake_swg = _make_fake_swg()
 
     with (
         patch(
@@ -100,6 +122,7 @@ def test_run_phase0_summary_keys(tmp_path):
             "studies.annotation_reranking.phase0.dataset_sha256",
             return_value="deadbeef" * 8,
         ),
+        _swg_patch(fake_swg),
     ):
         summary = run_phase0(
             csv_path="/fake/path.csv",
@@ -125,6 +148,7 @@ def test_run_phase0_summary_keys(tmp_path):
 def test_run_phase0_counts(tmp_path):
     """Retrievable/not_retrieved counts match the synthetic case set."""
     run_phase0 = _import_run_phase0()
+    fake_swg = _make_fake_swg()
 
     with (
         patch(
@@ -139,6 +163,7 @@ def test_run_phase0_counts(tmp_path):
             "studies.annotation_reranking.phase0.dataset_sha256",
             return_value="deadbeef" * 8,
         ),
+        _swg_patch(fake_swg),
     ):
         summary = run_phase0(
             csv_path="/fake/path.csv",
@@ -155,6 +180,7 @@ def test_run_phase0_counts(tmp_path):
 def test_run_phase0_writes_json(tmp_path):
     """run_phase0 writes phase0_regimes.json to out_dir."""
     run_phase0 = _import_run_phase0()
+    fake_swg = _make_fake_swg()
 
     with (
         patch(
@@ -169,6 +195,7 @@ def test_run_phase0_writes_json(tmp_path):
             "studies.annotation_reranking.phase0.dataset_sha256",
             return_value="abc123",
         ),
+        _swg_patch(fake_swg),
     ):
         run_phase0(
             csv_path="/fake/path.csv",
@@ -190,6 +217,7 @@ def test_run_phase0_writes_json(tmp_path):
 def test_run_phase0_per_case_structure(tmp_path):
     """Each per_case entry has name, regime, selected_id, review_flag."""
     run_phase0 = _import_run_phase0()
+    fake_swg = _make_fake_swg()
 
     with (
         patch(
@@ -204,6 +232,7 @@ def test_run_phase0_per_case_structure(tmp_path):
             "studies.annotation_reranking.phase0.dataset_sha256",
             return_value="abc123",
         ),
+        _swg_patch(fake_swg),
     ):
         run_phase0(
             csv_path="/fake/path.csv",
@@ -225,6 +254,7 @@ def test_run_phase0_per_case_structure(tmp_path):
 def test_run_phase0_default_out_dir(tmp_path, monkeypatch):
     """When out_dir uses default path, the JSON is still written."""
     run_phase0 = _import_run_phase0()
+    fake_swg = _make_fake_swg()
 
     default_dir = tmp_path / "studies" / "annotation_reranking" / "runs" / "phase0"
 
@@ -245,6 +275,7 @@ def test_run_phase0_default_out_dir(tmp_path, monkeypatch):
             "studies.annotation_reranking.phase0._DEFAULT_OUT_DIR",
             str(default_dir),
         ),
+        _swg_patch(fake_swg),
     ):
         summary = run_phase0(csv_path="/fake/path.csv", top_n=20)
 

--- a/tests/studies/annotation_reranking/test_phase0.py
+++ b/tests/studies/annotation_reranking/test_phase0.py
@@ -1,0 +1,251 @@
+"""Tests for phase0.py — Phase 0 decision gate.
+
+All network calls are mocked. We patch fetch_candidates and load_eval_cases
+so no live Kestrel / MW / PubChem traffic occurs in CI.
+"""
+import json
+import os
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from studies.annotation_reranking.models_data import Candidate, EvalCase
+
+
+# ---------------------------------------------------------------------------
+# Synthetic test data
+# ---------------------------------------------------------------------------
+
+def _candidate(cid: str, score: float = 2.0) -> Candidate:
+    return Candidate(id=cid, score=score, name=cid)
+
+
+# Case A: target CHEBI:28683 IS in candidates; SWG picks refmet (divergent_refmet flag)
+CASE_A = EvalCase(
+    name="compound_a",
+    level="",
+    refmet_id="28683",
+    refmet_name="compound_a_refmet",
+    biomapper_ids=["CHEBI:100"],
+    biomapper_name="compound_a",
+    category="metabolite",
+    correct_id=None,          # target_id → CHEBI:28683
+    label_source="refmet_agreement",
+)
+
+# Candidates for Case A: majority is CHEBI:100 (score 4.0), refmet CHEBI:28683 present (score 2.0)
+CANDS_A = [
+    _candidate("CHEBI:100", score=4.0),
+    _candidate("CHEBI:28683", score=2.0),
+]
+
+# Case B: target NOT in candidates → not_retrieved
+CASE_B = EvalCase(
+    name="compound_b",
+    level="",
+    refmet_id="99999",
+    refmet_name="compound_b_refmet",
+    biomapper_ids=["CHEBI:200"],
+    biomapper_name="compound_b",
+    category="metabolite",
+    correct_id=None,          # target_id → CHEBI:99999
+    label_source="refmet_agreement",
+)
+
+# Candidates for Case B: CHEBI:99999 is absent
+CANDS_B = [
+    _candidate("CHEBI:200", score=3.5),
+    _candidate("CHEBI:201", score=2.0),
+]
+
+
+def _side_effect_fetch(name: str, category: str, top_n: int = 20) -> list[Candidate]:
+    if name == "compound_a":
+        return CANDS_A
+    if name == "compound_b":
+        return CANDS_B
+    return []
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _import_run_phase0():
+    """Late import so patching load_eval_cases works at module level."""
+    from studies.annotation_reranking.phase0 import run_phase0
+    return run_phase0
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_run_phase0_summary_keys(tmp_path):
+    """run_phase0 returns a dict with all required summary keys."""
+    run_phase0 = _import_run_phase0()
+
+    with (
+        patch(
+            "studies.annotation_reranking.phase0.fetch_candidates",
+            side_effect=_side_effect_fetch,
+        ),
+        patch(
+            "studies.annotation_reranking.phase0.load_eval_cases",
+            return_value=[CASE_A, CASE_B],
+        ),
+        patch(
+            "studies.annotation_reranking.phase0.dataset_sha256",
+            return_value="deadbeef" * 8,
+        ),
+    ):
+        summary = run_phase0(
+            csv_path="/fake/path.csv",
+            top_n=20,
+            out_dir=str(tmp_path),
+        )
+
+    required_keys = {
+        "retrievable",
+        "not_retrieved",
+        "dataset_sha256",
+        "top_n",
+        "n_swg_disagrees_correct",
+        "flag_divergent_refmet",
+        "flag_conflict_no_structure",
+        "flag_none",
+    }
+    assert required_keys.issubset(summary.keys()), (
+        f"Missing keys: {required_keys - summary.keys()}"
+    )
+
+
+def test_run_phase0_counts(tmp_path):
+    """Retrievable/not_retrieved counts match the synthetic case set."""
+    run_phase0 = _import_run_phase0()
+
+    with (
+        patch(
+            "studies.annotation_reranking.phase0.fetch_candidates",
+            side_effect=_side_effect_fetch,
+        ),
+        patch(
+            "studies.annotation_reranking.phase0.load_eval_cases",
+            return_value=[CASE_A, CASE_B],
+        ),
+        patch(
+            "studies.annotation_reranking.phase0.dataset_sha256",
+            return_value="deadbeef" * 8,
+        ),
+    ):
+        summary = run_phase0(
+            csv_path="/fake/path.csv",
+            top_n=20,
+            out_dir=str(tmp_path),
+        )
+
+    assert summary["retrievable"] == 1   # Case A only
+    assert summary["not_retrieved"] == 1  # Case B only
+    assert summary["top_n"] == 20
+    assert summary["dataset_sha256"] == "deadbeef" * 8
+
+
+def test_run_phase0_writes_json(tmp_path):
+    """run_phase0 writes phase0_regimes.json to out_dir."""
+    run_phase0 = _import_run_phase0()
+
+    with (
+        patch(
+            "studies.annotation_reranking.phase0.fetch_candidates",
+            side_effect=_side_effect_fetch,
+        ),
+        patch(
+            "studies.annotation_reranking.phase0.load_eval_cases",
+            return_value=[CASE_A, CASE_B],
+        ),
+        patch(
+            "studies.annotation_reranking.phase0.dataset_sha256",
+            return_value="abc123",
+        ),
+    ):
+        run_phase0(
+            csv_path="/fake/path.csv",
+            top_n=20,
+            out_dir=str(tmp_path),
+        )
+
+    json_path = tmp_path / "phase0_regimes.json"
+    assert json_path.exists(), "phase0_regimes.json was not written"
+
+    with open(json_path) as f:
+        data = json.load(f)
+
+    assert "summary" in data
+    assert "per_case" in data
+    assert len(data["per_case"]) == 2
+
+
+def test_run_phase0_per_case_structure(tmp_path):
+    """Each per_case entry has name, regime, selected_id, review_flag."""
+    run_phase0 = _import_run_phase0()
+
+    with (
+        patch(
+            "studies.annotation_reranking.phase0.fetch_candidates",
+            side_effect=_side_effect_fetch,
+        ),
+        patch(
+            "studies.annotation_reranking.phase0.load_eval_cases",
+            return_value=[CASE_A, CASE_B],
+        ),
+        patch(
+            "studies.annotation_reranking.phase0.dataset_sha256",
+            return_value="abc123",
+        ),
+    ):
+        run_phase0(
+            csv_path="/fake/path.csv",
+            top_n=20,
+            out_dir=str(tmp_path),
+        )
+
+    with open(tmp_path / "phase0_regimes.json") as f:
+        data = json.load(f)
+
+    for entry in data["per_case"]:
+        assert "name" in entry
+        assert "regime" in entry
+        assert "selected_id" in entry
+        assert "review_flag" in entry
+        assert entry["regime"] in {"retrievable", "not_retrieved"}
+
+
+def test_run_phase0_default_out_dir(tmp_path, monkeypatch):
+    """When out_dir uses default path, the JSON is still written."""
+    run_phase0 = _import_run_phase0()
+
+    default_dir = tmp_path / "studies" / "annotation_reranking" / "runs" / "phase0"
+
+    with (
+        patch(
+            "studies.annotation_reranking.phase0.fetch_candidates",
+            side_effect=_side_effect_fetch,
+        ),
+        patch(
+            "studies.annotation_reranking.phase0.load_eval_cases",
+            return_value=[CASE_A],
+        ),
+        patch(
+            "studies.annotation_reranking.phase0.dataset_sha256",
+            return_value="abc123",
+        ),
+        patch(
+            "studies.annotation_reranking.phase0._DEFAULT_OUT_DIR",
+            str(default_dir),
+        ),
+    ):
+        summary = run_phase0(csv_path="/fake/path.csv", top_n=20)
+
+    assert (default_dir / "phase0_regimes.json").exists()

--- a/tests/studies/annotation_reranking/test_regimes.py
+++ b/tests/studies/annotation_reranking/test_regimes.py
@@ -1,0 +1,129 @@
+"""Tests for regimes.py — retrievability + divergence tagging.
+
+All tests are pure/synthetic: no network calls, no CSV on disk.
+"""
+import pytest
+
+from studies.annotation_reranking.models_data import Candidate, EvalCase
+from studies.annotation_reranking.regimes import (
+    classify_regime,
+    is_retrievable,
+    target_id,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _c(cid: str, score: float = 1.0) -> Candidate:
+    return Candidate(id=cid, score=score, name=cid)
+
+
+def _case(
+    refmet_id: str = "12345",
+    correct_id: str | None = None,
+    name: str = "test_compound",
+) -> EvalCase:
+    return EvalCase(
+        name=name,
+        level="",
+        refmet_id=refmet_id,
+        refmet_name="",
+        biomapper_ids=[],
+        biomapper_name="",
+        category="",
+        correct_id=correct_id,
+        label_source="refmet_agreement",
+    )
+
+
+# ---------------------------------------------------------------------------
+# target_id tests
+# ---------------------------------------------------------------------------
+
+
+def test_target_id_uses_correct_id_when_set():
+    case = _case(refmet_id="99999", correct_id="CHEBI:00042")
+    assert target_id(case) == "CHEBI:00042"
+
+
+def test_target_id_falls_back_to_refmet_when_correct_id_none():
+    case = _case(refmet_id="28683", correct_id=None)
+    assert target_id(case) == "CHEBI:28683"
+
+
+def test_target_id_strips_whitespace_from_refmet_id():
+    case = _case(refmet_id="  28683  ", correct_id=None)
+    assert target_id(case) == "CHEBI:28683"
+
+
+def test_target_id_correct_id_takes_precedence_over_refmet():
+    """correct_id wins even if refmet_id is also set."""
+    case = _case(refmet_id="99999", correct_id="CHEBI:00007")
+    assert target_id(case) == "CHEBI:00007"
+
+
+# ---------------------------------------------------------------------------
+# is_retrievable tests
+# ---------------------------------------------------------------------------
+
+
+def test_is_retrievable_true_when_target_present():
+    case = _case(refmet_id="28683")
+    candidates = [_c("CHEBI:100"), _c("CHEBI:28683"), _c("CHEBI:200")]
+    assert is_retrievable(case, candidates) is True
+
+
+def test_is_retrievable_false_when_target_absent():
+    case = _case(refmet_id="28683")
+    candidates = [_c("CHEBI:100"), _c("CHEBI:999")]
+    assert is_retrievable(case, candidates) is False
+
+
+def test_is_retrievable_false_when_candidates_empty():
+    case = _case(refmet_id="28683")
+    assert is_retrievable(case, []) is False
+
+
+def test_is_retrievable_uses_correct_id_over_refmet():
+    """correct_id != refmet — only correct_id matters for retrievability."""
+    case = _case(refmet_id="28683", correct_id="CHEBI:99999")
+    # CHEBI:28683 is present but CHEBI:99999 is not
+    candidates = [_c("CHEBI:28683"), _c("CHEBI:100")]
+    assert is_retrievable(case, candidates) is False
+
+
+def test_is_retrievable_true_with_correct_id():
+    case = _case(refmet_id="28683", correct_id="CHEBI:99999")
+    candidates = [_c("CHEBI:99999"), _c("CHEBI:28683")]
+    assert is_retrievable(case, candidates) is True
+
+
+# ---------------------------------------------------------------------------
+# classify_regime tests
+# ---------------------------------------------------------------------------
+
+
+def test_classify_regime_retrievable():
+    case = _case(refmet_id="28683")
+    candidates = [_c("CHEBI:28683"), _c("CHEBI:100")]
+    assert classify_regime(case, candidates) == "retrievable"
+
+
+def test_classify_regime_not_retrieved():
+    case = _case(refmet_id="28683")
+    candidates = [_c("CHEBI:100"), _c("CHEBI:200")]
+    assert classify_regime(case, candidates) == "not_retrieved"
+
+
+def test_classify_regime_empty_candidates_is_not_retrieved():
+    case = _case(refmet_id="28683")
+    assert classify_regime(case, []) == "not_retrieved"
+
+
+def test_classify_regime_uses_correct_id():
+    """classify_regime delegates to is_retrievable which uses target_id."""
+    case = _case(refmet_id="28683", correct_id="CHEBI:55555")
+    candidates = [_c("CHEBI:55555")]
+    assert classify_regime(case, candidates) == "retrievable"

--- a/tests/studies/annotation_reranking/test_register_llms.py
+++ b/tests/studies/annotation_reranking/test_register_llms.py
@@ -1,0 +1,118 @@
+"""Tests for _register_llms in studies/annotation_reranking/run.py.
+
+TDD (Task 9): test written first (RED), then implementation added (GREEN).
+
+The test verifies that after _register_llms registers an LLM reranker with a
+stubbed call_fn, calling select() on that reranker properly populates
+last_cost_usd and last_latency_s — proving that the seam feeds score_case
+(which reads those fields after select() returns).
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from studies.annotation_reranking.models_data import Candidate, EvalCase
+from studies.annotation_reranking.rerankers.base import REGISTRY
+from studies.annotation_reranking.run import _register_llms
+
+
+def _c(cid: str) -> Candidate:
+    return Candidate(id=cid, score=1.0, name=cid, equivalent_ids=[])
+
+
+def _case() -> EvalCase:
+    return EvalCase(
+        name="test",
+        level="MS1",
+        refmet_id="1",
+        refmet_name="",
+        biomapper_ids=[],
+        biomapper_name="",
+        category="metabolite",
+        correct_id=None,
+        label_source="refmet_agreement",
+    )
+
+
+# ---------------------------------------------------------------------------
+# _register_llms tests
+# ---------------------------------------------------------------------------
+
+
+class TestRegisterLlms:
+    def setup_method(self):
+        """Snapshot REGISTRY before test so we can clean up after."""
+        self._pre_keys = set(REGISTRY.keys())
+
+    def teardown_method(self):
+        """Remove any keys added by _register_llms during this test."""
+        for k in list(REGISTRY.keys()):
+            if k not in self._pre_keys:
+                del REGISTRY[k]
+
+    def test_registers_both_blind_and_non_blind(self):
+        """_register_llms adds both blind and non-blind entries for the model."""
+        with patch(
+            "studies.annotation_reranking.run.call_model",
+            return_value=("CHEBI:1", 0.0, 0.0),
+        ):
+            _register_llms(["sonnet"])
+
+        assert "llm:sonnet/blind" in REGISTRY
+        assert "llm:sonnet" in REGISTRY
+
+    def test_select_sets_last_cost_and_latency(self):
+        """After select(), last_cost_usd and last_latency_s reflect the stub return values.
+
+        This is the key seam: score_case reads these attributes off the reranker
+        after select() returns.  The test proves _register_llms wires call_model
+        into the LlmReranker correctly.
+        """
+        with patch(
+            "studies.annotation_reranking.run.call_model",
+            return_value=("CHEBI:1", 0.0123, 0.4),
+        ):
+            _register_llms(["sonnet"])
+
+        reranker = REGISTRY["llm:sonnet/blind"]
+        cands = [_c("CHEBI:1")]
+
+        # call_model is already patched via _register_llms above — the call_fn
+        # captured inside _register_llms is a closure that calls call_model.
+        # We re-patch here so the reranker's closure hits the patched version
+        # when select() fires.
+        with patch(
+            "studies.annotation_reranking.run.call_model",
+            return_value=("CHEBI:1", 0.0123, 0.4),
+        ):
+            selected_id, review_flag = reranker.select(cands, _case())
+
+        assert selected_id == "CHEBI:1"
+        assert review_flag is None
+        assert reranker.last_cost_usd == pytest.approx(0.0123)
+        assert reranker.last_latency_s == pytest.approx(0.4)
+
+    def test_last_cost_and_latency_initialized_to_zero(self):
+        """Before any select() call, last_cost_usd and last_latency_s default to 0.0."""
+        with patch(
+            "studies.annotation_reranking.run.call_model",
+            return_value=("CHEBI:1", 0.0, 0.0),
+        ):
+            _register_llms(["sonnet"])
+
+        reranker = REGISTRY["llm:sonnet/blind"]
+        assert reranker.last_cost_usd == 0.0
+        assert reranker.last_latency_s == 0.0
+
+    def test_empty_model_list_registers_nothing_extra(self):
+        """_register_llms([]) must not add any new LLM entries to REGISTRY."""
+        _register_llms([])
+        new_keys = set(REGISTRY.keys()) - self._pre_keys
+        assert new_keys == set()
+
+    def test_unknown_label_raises_key_error(self):
+        """An unrecognised model label (not in ROSTER) should raise KeyError."""
+        with pytest.raises(KeyError):
+            _register_llms(["not_a_real_model"])

--- a/tests/studies/annotation_reranking/test_retrieval.py
+++ b/tests/studies/annotation_reranking/test_retrieval.py
@@ -28,6 +28,24 @@ def test_top_n_is_passed_through():
     assert captured["limit"] == 15
 
 
+def test_fetch_equivalent_ids_flattening():
+    """_fetch_equivalent_ids must flatten {curie: {prefix: [local_ids]}} to {curie: [CURIE, ...]}."""
+    from unittest.mock import patch
+    from biomapper2.core.linker import Linker
+
+    nested = {"CHEBI:15365": {"RM": ["0001"], "HMDB": ["HMDB0001879"]}}
+    with patch.object(Linker, "get_equivalent_ids", return_value=nested):
+        result = retrieval._fetch_equivalent_ids(["CHEBI:15365"])
+
+    assert set(result["CHEBI:15365"]) == {"RM:0001", "HMDB:HMDB0001879"}
+
+    # A Candidate built from those equivalent_ids must have has_refmet() True.
+    from studies.annotation_reranking.models_data import Candidate
+    c = Candidate(id="CHEBI:15365", score=1.0, name="aspirin",
+                  equivalent_ids=result["CHEBI:15365"])
+    assert c.has_refmet() is True
+
+
 import os, pytest
 
 @pytest.mark.external

--- a/tests/studies/annotation_reranking/test_retrieval.py
+++ b/tests/studies/annotation_reranking/test_retrieval.py
@@ -1,0 +1,38 @@
+from unittest.mock import patch
+from studies.annotation_reranking import retrieval
+from studies.annotation_reranking.models_data import Candidate
+
+FAKE_SEARCH = {"1-methylhistidine": [
+    {"id": "CHEBI:70958", "score": 4.9, "name": "1-methylhistidine", "synonyms": []},
+    {"id": "CHEBI:27596", "score": 4.1, "name": "N(pros)-methyl-L-histidine", "synonyms": []},
+]}
+FAKE_EQUIV = {"CHEBI:70958": ["RM:0001", "HMDB:0000001"], "CHEBI:27596": ["HMDB:0000479"]}
+
+def test_fetch_returns_enriched_candidates():
+    with patch.object(retrieval, "_raw_hybrid_search", return_value=FAKE_SEARCH), \
+         patch.object(retrieval, "_fetch_equivalent_ids", return_value=FAKE_EQUIV):
+        cands = retrieval.fetch_candidates("1-methylhistidine", "metabolite", top_n=20)
+    assert [c.id for c in cands] == ["CHEBI:70958", "CHEBI:27596"]
+    assert isinstance(cands[0], Candidate)
+    assert cands[0].equivalent_ids == ["RM:0001", "HMDB:0000001"]
+    assert cands[0].has_refmet() and not cands[1].has_refmet()
+
+def test_top_n_is_passed_through():
+    captured = {}
+    def spy(text, category, prefixes, limit):
+        captured["limit"] = limit
+        return {text: []}
+    with patch.object(retrieval, "_raw_hybrid_search", side_effect=spy), \
+         patch.object(retrieval, "_fetch_equivalent_ids", return_value={}):
+        retrieval.fetch_candidates("x", "metabolite", top_n=15)
+    assert captured["limit"] == 15
+
+
+import os, pytest
+
+@pytest.mark.external
+@pytest.mark.skipif(not os.getenv("KESTREL_API_KEY"), reason="needs KESTREL_API_KEY")
+def test_live_fetch_one_case():
+    cands = retrieval.fetch_candidates("1-methylhistidine", "metabolite", top_n=20)
+    assert 1 <= len(cands) <= 20
+    assert all(c.id.startswith("CHEBI:") for c in cands)

--- a/tests/studies/annotation_reranking/test_run.py
+++ b/tests/studies/annotation_reranking/test_run.py
@@ -266,3 +266,38 @@ class TestRunMatrix:
             manifest = json.load(fh)
 
         assert manifest["temperature"] == 0
+
+    def _csv_with_taxonomy_category(self, tmp_path) -> str:
+        """Write a 1-row CSV where category is a disagreement taxonomy label (NOT 'metabolite').
+
+        This is critical for the regression test: if the fixture category were 'metabolite'
+        the test could not distinguish whether run_matrix passed case.category or the
+        literal 'metabolite' to fetch_candidates.
+        """
+        csv_path = str(tmp_path / "test_taxonomy.csv")
+        with open(csv_path, "w") as fh:
+            fh.write("name,level,refmet_id,refmet_name,biomapper_id,biomapper_name,category\n")
+            fh.write(
+                "glucose,MS1,28,Glucose,CHEBI:17234,Glucose,"
+                "divergent (different compound)\n"
+            )
+        return csv_path
+
+    def test_fetch_candidates_always_called_with_metabolite_category(self, tmp_path):
+        """Regression: run_matrix must pass 'metabolite' to fetch_candidates, never case.category.
+
+        The CSV row has category='divergent (different compound)' — a disagreement taxonomy
+        label, not a biolink entity type. If run_matrix ever regresses to passing case.category
+        the mock assertion below will catch it.
+        """
+        csv_path = self._csv_with_taxonomy_category(tmp_path)
+        out_dir = str(tmp_path / "run_out_regression")
+
+        with patch(
+            "studies.annotation_reranking.run.fetch_candidates",
+            return_value=[],
+        ) as mock_fetch:
+            run_matrix(csv_path=csv_path, top_n=5, seeds=(0,), out_dir=out_dir)
+
+        # Every call must use the literal "metabolite", not the taxonomy category string.
+        mock_fetch.assert_called_once_with("glucose", "metabolite", top_n=5)

--- a/tests/studies/annotation_reranking/test_run.py
+++ b/tests/studies/annotation_reranking/test_run.py
@@ -301,3 +301,54 @@ class TestRunMatrix:
 
         # Every call must use the literal "metabolite", not the taxonomy category string.
         mock_fetch.assert_called_once_with("glucose", "metabolite", top_n=5)
+
+
+# ---------------------------------------------------------------------------
+# run_matrix — derive_labels wiring (Task 10)
+# ---------------------------------------------------------------------------
+
+class TestRunMatrixDeriveLabels:
+    def _minimal_csv(self, tmp_path) -> str:
+        csv_path = str(tmp_path / "test_dl.csv")
+        with open(csv_path, "w") as fh:
+            fh.write("name,level,refmet_id,refmet_name,biomapper_id,biomapper_name,category\n")
+            fh.write("glucose,MS1,28,Glucose,CHEBI:17234,Glucose,metabolite\n")
+        return csv_path
+
+    def test_derive_labels_invoked_when_flag_true(self, tmp_path):
+        """run_matrix with derive_labels=True must call labels.derive_labels on the cases."""
+        csv_path = self._minimal_csv(tmp_path)
+        out_dir = str(tmp_path / "run_out_dl")
+
+        with (
+            patch(
+                "studies.annotation_reranking.run.fetch_candidates",
+                return_value=[],
+            ),
+            patch(
+                "studies.annotation_reranking.run._labels_module.derive_labels",
+                return_value=[],
+            ) as mock_derive,
+        ):
+            run_matrix(csv_path=csv_path, top_n=5, seeds=(0,), out_dir=out_dir, derive_labels=True)
+
+        mock_derive.assert_called_once()
+
+    def test_derive_labels_not_invoked_by_default(self, tmp_path):
+        """run_matrix with default derive_labels=False must NOT call labels.derive_labels."""
+        csv_path = self._minimal_csv(tmp_path)
+        out_dir = str(tmp_path / "run_out_no_dl")
+
+        with (
+            patch(
+                "studies.annotation_reranking.run.fetch_candidates",
+                return_value=[],
+            ),
+            patch(
+                "studies.annotation_reranking.run._labels_module.derive_labels",
+                return_value=[],
+            ) as mock_derive,
+        ):
+            run_matrix(csv_path=csv_path, top_n=5, seeds=(0,), out_dir=out_dir)
+
+        mock_derive.assert_not_called()

--- a/tests/studies/annotation_reranking/test_run.py
+++ b/tests/studies/annotation_reranking/test_run.py
@@ -1,0 +1,268 @@
+"""Tests for studies/annotation_reranking/run.py — Task 8 orchestrator.
+
+TDD: tests are written first (RED), then run.py is implemented (GREEN).
+
+Amendment-aware: uses 2-arg classify_regime(case, candidates), 2-tuple unpack
+from reranker.select, and verifies cost_usd/latency_s seam.
+"""
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from unittest.mock import patch
+
+import pytest
+
+from studies.annotation_reranking.models_data import Candidate, EvalCase, RerankResult
+from studies.annotation_reranking.rerankers.deterministic import RmAnchorReranker
+from studies.annotation_reranking.run import build_manifest, score_case, run_matrix
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _case(correct_id: str | None, label_source: str) -> EvalCase:
+    """Minimal EvalCase factory."""
+    return EvalCase(
+        name="test_metabolite",
+        level="MS2",
+        refmet_id="1",
+        refmet_name="refmet_name",
+        biomapper_ids=["CHEBI:2"],
+        biomapper_name="biomapper_name",
+        category="metabolite",
+        correct_id=correct_id,
+        label_source=label_source,
+    )
+
+
+def _cand(cid: str, score: float = 3.0, has_rm: bool = False) -> Candidate:
+    equiv = ["RM:1"] if has_rm else []
+    return Candidate(id=cid, score=score, name=cid, equivalent_ids=equiv)
+
+
+# ---------------------------------------------------------------------------
+# build_manifest
+# ---------------------------------------------------------------------------
+
+class TestBuildManifest:
+    def test_pins_reproducibility_fields(self):
+        m = build_manifest("SOME.csv", 20, (0, 1, 2), [], "test-box")
+        for key in ("dataset_sha256", "top_n", "seeds", "temperature", "models", "hardware"):
+            assert key in m, f"Missing key: {key}"
+
+    def test_temperature_is_zero(self):
+        m = build_manifest("SOME.csv", 20, (0, 1, 2), [], "test-box")
+        assert m["temperature"] == 0
+
+    def test_hardware_pinned(self):
+        m = build_manifest("SOME.csv", 20, (0,), [], "my-gpu-box")
+        assert m["hardware"] == "my-gpu-box"
+
+    def test_seeds_preserved(self):
+        m = build_manifest("SOME.csv", 10, (0, 1, 2), [], "box")
+        assert m["seeds"] == [0, 1, 2]
+
+    def test_top_n_preserved(self):
+        m = build_manifest("SOME.csv", 15, (0,), [], "box")
+        assert m["top_n"] == 15
+
+
+# ---------------------------------------------------------------------------
+# score_case — shadow paths
+# ---------------------------------------------------------------------------
+
+class TestScoreCaseEmptyCandidates:
+    def test_error_is_empty_candidates(self):
+        r = score_case(_case("CHEBI:9", "independent_refmet_error"), [], RmAnchorReranker(), None)
+        assert r.error == "empty_candidates"
+
+    def test_selected_id_is_none(self):
+        r = score_case(_case("CHEBI:9", "independent_refmet_error"), [], RmAnchorReranker(), None)
+        assert r.selected_id is None
+
+    def test_is_correct_is_false(self):
+        r = score_case(_case("CHEBI:9", "independent_refmet_error"), [], RmAnchorReranker(), None)
+        assert r.is_correct is False
+
+    def test_review_flag_is_none(self):
+        r = score_case(_case("CHEBI:9", "independent_refmet_error"), [], RmAnchorReranker(), None)
+        assert r.review_flag is None
+
+
+class TestScoreCaseRefmetAgreement:
+    def test_is_unscored_when_no_correct_id(self):
+        """refmet_agreement cases have correct_id=None → is_correct must be None."""
+        cands = [_cand("CHEBI:2", has_rm=True)]
+        r = score_case(_case(None, "refmet_agreement"), cands, RmAnchorReranker(), None)
+        assert r.is_correct is None
+
+
+class TestScoreCaseIndependent:
+    def test_correct_pick_scores_true(self):
+        """RmAnchorReranker picks the RM-bearing candidate; correct_id matches."""
+        cands = [
+            _cand("CHEBI:9", score=3.0, has_rm=False),
+            _cand("CHEBI:2", score=5.0, has_rm=True),  # rm_anchor will pick this
+        ]
+        # correct_id = CHEBI:2 (the RM-bearing one rm_anchor picks)
+        r = score_case(_case("CHEBI:2", "independent_biomapper_error"), cands, RmAnchorReranker(), None)
+        assert r.selected_id == "CHEBI:2"
+        assert r.is_correct is True
+
+    def test_wrong_pick_scores_false(self):
+        cands = [
+            _cand("CHEBI:9", score=3.0, has_rm=False),
+            _cand("CHEBI:2", score=5.0, has_rm=True),  # rm_anchor will pick CHEBI:2
+        ]
+        # correct_id = CHEBI:9, but rm_anchor picks CHEBI:2
+        r = score_case(_case("CHEBI:9", "independent_biomapper_error"), cands, RmAnchorReranker(), None)
+        assert r.selected_id == "CHEBI:2"
+        assert r.is_correct is False
+
+
+class TestScoreCaseReviewFlag:
+    def test_review_flag_threaded_through(self):
+        """A reranker stub that returns a review_flag must have it stored on RerankResult."""
+
+        class StubReranker:
+            name = "stub_with_flag"
+
+            def select(self, candidates, case=None):
+                return candidates[0].id, "divergent_refmet"
+
+        cands = [_cand("CHEBI:9")]
+        r = score_case(_case("CHEBI:9", "independent_biomapper_error"), cands, StubReranker(), None)
+        assert r.review_flag == "divergent_refmet"
+        assert r.is_correct is True
+
+
+class TestScoreCaseCostLatencySeam:
+    def test_reads_last_cost_and_latency_from_reranker(self):
+        """score_case reads last_cost_usd and last_latency_s off reranker after select."""
+
+        class LlmStub:
+            name = "llm_stub"
+            last_cost_usd: float = 0.0
+            last_latency_s: float = 0.0
+
+            def select(self, candidates, case=None):
+                self.last_cost_usd = 0.042
+                self.last_latency_s = 1.23
+                return candidates[0].id, None
+
+        stub = LlmStub()
+        cands = [_cand("CHEBI:9")]
+        r = score_case(_case("CHEBI:9", "independent_biomapper_error"), cands, stub, "gpt-4o")
+        assert r.cost_usd == pytest.approx(0.042)
+        assert r.latency_s == pytest.approx(1.23)
+
+    def test_defaults_to_zero_when_absent(self):
+        """Deterministic rerankers don't set last_cost_usd; score_case defaults to 0.0."""
+        cands = [_cand("CHEBI:9", has_rm=True)]
+        r = score_case(_case("CHEBI:9", "independent_biomapper_error"), cands, RmAnchorReranker(), None)
+        assert r.cost_usd == 0.0
+        assert r.latency_s == 0.0
+
+
+class TestScoreCaseExceptionHandling:
+    def test_exception_stored_as_error(self):
+        """Reranker that raises an exception → error=str(e), is_correct=False."""
+
+        class BrokenReranker:
+            name = "broken"
+
+            def select(self, candidates, case=None):
+                raise RuntimeError("api timeout")
+
+        cands = [_cand("CHEBI:9")]
+        r = score_case(_case("CHEBI:9", "independent_biomapper_error"), cands, BrokenReranker(), None)
+        assert r.error == "api timeout"
+        assert r.is_correct is False
+        assert r.selected_id is None
+
+    def test_off_list_none_marks_error(self):
+        """Reranker returning (None, None) → error='off_list'."""
+
+        class OffListReranker:
+            name = "off_list_reranker"
+
+            def select(self, candidates, case=None):
+                return None, None
+
+        cands = [_cand("CHEBI:9")]
+        r = score_case(_case("CHEBI:9", "independent_biomapper_error"), cands, OffListReranker(), None)
+        assert r.error == "off_list"
+        assert r.is_correct is False
+
+
+# ---------------------------------------------------------------------------
+# run_matrix — network-mocked integration test
+# ---------------------------------------------------------------------------
+
+class TestRunMatrix:
+    def _minimal_csv(self, tmp_path) -> str:
+        """Write a 1-row CSV compatible with load_eval_cases."""
+        csv_path = str(tmp_path / "test.csv")
+        with open(csv_path, "w") as fh:
+            fh.write("name,level,refmet_id,refmet_name,biomapper_id,biomapper_name,category\n")
+            fh.write("glucose,MS1,28,Glucose,CHEBI:17234,Glucose,metabolite\n")
+        return csv_path
+
+    def test_run_matrix_writes_manifest_and_results(self, tmp_path):
+        csv_path = self._minimal_csv(tmp_path)
+        out_dir = str(tmp_path / "run_out")
+
+        fake_candidates = [_cand("CHEBI:17234", score=4.5, has_rm=True)]
+
+        with patch(
+            "studies.annotation_reranking.run.fetch_candidates",
+            return_value=fake_candidates,
+        ):
+            returned_path = run_matrix(
+                csv_path=csv_path,
+                top_n=5,
+                seeds=(0,),
+                out_dir=out_dir,
+            )
+
+        assert returned_path == out_dir
+        assert os.path.isfile(os.path.join(out_dir, "manifest.json"))
+        assert os.path.isfile(os.path.join(out_dir, "results.jsonl"))
+
+    def test_run_matrix_results_have_required_fields(self, tmp_path):
+        csv_path = self._minimal_csv(tmp_path)
+        out_dir = str(tmp_path / "run_out2")
+
+        fake_candidates = [_cand("CHEBI:17234", score=4.5, has_rm=True)]
+
+        with patch(
+            "studies.annotation_reranking.run.fetch_candidates",
+            return_value=fake_candidates,
+        ):
+            run_matrix(csv_path=csv_path, top_n=5, seeds=(0,), out_dir=out_dir)
+
+        with open(os.path.join(out_dir, "results.jsonl")) as fh:
+            lines = fh.readlines()
+
+        assert len(lines) > 0
+        record = json.loads(lines[0])
+        for field in ("selected_id", "is_correct", "regime", "cost_usd", "latency_s", "review_flag"):
+            assert field in record, f"Missing field in results.jsonl: {field}"
+
+    def test_run_matrix_manifest_temperature_zero(self, tmp_path):
+        csv_path = self._minimal_csv(tmp_path)
+        out_dir = str(tmp_path / "run_out3")
+
+        with patch(
+            "studies.annotation_reranking.run.fetch_candidates",
+            return_value=[],
+        ):
+            run_matrix(csv_path=csv_path, top_n=5, seeds=(0,), out_dir=out_dir)
+
+        with open(os.path.join(out_dir, "manifest.json")) as fh:
+            manifest = json.load(fh)
+
+        assert manifest["temperature"] == 0

--- a/tests/studies/annotation_reranking/test_run.py
+++ b/tests/studies/annotation_reranking/test_run.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import json
 import os
 import tempfile
+from unittest import mock
 from unittest.mock import patch
 
 import pytest
@@ -316,9 +317,12 @@ class TestRunMatrixDeriveLabels:
         return csv_path
 
     def test_derive_labels_invoked_when_flag_true(self, tmp_path):
-        """run_matrix with derive_labels=True must call labels.derive_labels on the cases."""
+        """run_matrix with derive_labels=True must call labels.derive_labels on the loaded cases."""
         csv_path = self._minimal_csv(tmp_path)
         out_dir = str(tmp_path / "run_out_dl")
+
+        # A real non-empty sentinel list so we can verify the exact object passed.
+        sentinel_cases = [_case(None, "refmet_agreement")]
 
         with (
             patch(
@@ -326,13 +330,23 @@ class TestRunMatrixDeriveLabels:
                 return_value=[],
             ),
             patch(
+                "studies.annotation_reranking.run.load_eval_cases",
+                return_value=sentinel_cases,
+            ),
+            patch(
                 "studies.annotation_reranking.run._labels_module.derive_labels",
-                return_value=[],
+                return_value=sentinel_cases,
             ) as mock_derive,
         ):
             run_matrix(csv_path=csv_path, top_n=5, seeds=(0,), out_dir=out_dir, derive_labels=True)
 
-        mock_derive.assert_called_once()
+        # Verify called exactly once AND with the cases list (not csv_path or empty list).
+        mock_derive.assert_called_once_with(mock.ANY)
+        actual_arg = mock_derive.call_args[0][0]
+        assert actual_arg is sentinel_cases, (
+            f"derive_labels was called with {type(actual_arg)!r} instead of the cases list"
+        )
+        assert len(actual_arg) > 0, "derive_labels must not be called with an empty list"
 
     def test_derive_labels_not_invoked_by_default(self, tmp_path):
         """run_matrix with default derive_labels=False must NOT call labels.derive_labels."""

--- a/tests/studies/annotation_reranking/test_scoring.py
+++ b/tests/studies/annotation_reranking/test_scoring.py
@@ -1,5 +1,17 @@
 import math
-from studies.annotation_reranking.scoring import wilson_ci, mcnemar_exact, min_discordant_for_sig
+import pytest
+from studies.annotation_reranking.scoring import wilson_ci, mcnemar_exact, min_discordant_for_sig, accuracy
+from studies.annotation_reranking.models_data import RerankResult
+
+
+def _make_result(is_correct, regime):
+    return RerankResult(
+        case_name="x", reranker="r", model=None,
+        selected_id="CHEBI:1", correct_id="CHEBI:1",
+        label_source="independent_biomapper_error",
+        regime=regime, is_correct=is_correct,
+        cost_usd=0.0, latency_s=0.0,
+    )
 
 
 def test_wilson_ci_bounds_are_ordered_and_in_unit_interval():
@@ -26,3 +38,29 @@ def test_min_discordant_threshold_matches_doc_claim():
     # the "≥6 discordant pairs to clear p<0.05" fact the design doc cites
     assert min_discordant_for_sig(6) <= 6
     assert min_discordant_for_sig(4) > 4   # 4 discordant can't reach significance
+
+
+def test_accuracy_retrievable_only_filters_non_retrievable():
+    """retrievable_only=True must exclude non-retrievable cases from the denominator."""
+    # 3 scored cases: 1 correct+retrievable, 1 wrong+retrievable, 1 wrong+not_in_top_n
+    results = [
+        _make_result(True,  "retrievable"),      # correct & retrievable
+        _make_result(False, "retrievable"),      # wrong & retrievable
+        _make_result(False, "not_in_top_n"),     # wrong & non-retrievable
+        _make_result(None,  "retrievable"),      # unscored — always excluded
+    ]
+    # Without retrievable_only: 1 correct out of 3 scored = 1/3
+    point_all, _ = accuracy(results)
+    assert point_all == pytest.approx(1 / 3)
+
+    # With retrievable_only: non-retrievable wrong case excluded → 1 correct out of 2 = 0.5
+    point_retr, _ = accuracy(results, retrievable_only=True)
+    assert point_retr == 0.5
+
+    # Also verify: non-retrievable correct case is excluded when flag is set.
+    results_with_unreachable = results + [_make_result(True, "not_in_top_n")]
+    point_all2, _ = accuracy(results_with_unreachable)
+    assert point_all2 == pytest.approx(2 / 4)   # 2 correct out of 4 scored
+
+    point_retr2, _ = accuracy(results_with_unreachable, retrievable_only=True)
+    assert point_retr2 == 0.5   # non-retrievable correct case excluded; still 1/2

--- a/tests/studies/annotation_reranking/test_scoring.py
+++ b/tests/studies/annotation_reranking/test_scoring.py
@@ -1,0 +1,28 @@
+import math
+from studies.annotation_reranking.scoring import wilson_ci, mcnemar_exact, min_discordant_for_sig
+
+
+def test_wilson_ci_bounds_are_ordered_and_in_unit_interval():
+    lo, hi = wilson_ci(1, 13)
+    assert 0.0 <= lo < hi <= 1.0
+
+
+def test_mcnemar_all_discordant_one_direction_is_significant():
+    a = [True]*6 + [False]*7   # model A correct on 6 where B wrong
+    b = [False]*6 + [False]*7
+    b01, b10, p = mcnemar_exact(a, b)
+    assert b10 == 6 and b01 == 0
+    assert p < 0.05
+
+
+def test_mcnemar_small_delta_not_significant():
+    a = [True, True, False, False]
+    b = [False, True, True, False]   # 1 vs 1 discordant
+    _, _, p = mcnemar_exact(a, b)
+    assert p > 0.05
+
+
+def test_min_discordant_threshold_matches_doc_claim():
+    # the "≥6 discordant pairs to clear p<0.05" fact the design doc cites
+    assert min_discordant_for_sig(6) <= 6
+    assert min_discordant_for_sig(4) > 4   # 4 discordant can't reach significance

--- a/tests/studies/conftest.py
+++ b/tests/studies/conftest.py
@@ -1,0 +1,9 @@
+import sys
+import os
+
+# Make the repo root importable so `studies.*` packages can be found.
+# studies/ lives at the repo root (not under src/), so it is not on the
+# default sys.path that hatchling's editable install provides.
+_repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+if _repo_root not in sys.path:
+    sys.path.insert(0, _repo_root)


### PR DESCRIPTION
## Study: annotation-reranking ablation harness

A self-contained study harness (`studies/annotation_reranking/`) that retrieves top-N candidate metabolite nodes from Kestrel, runs deterministic + LLM rerankers over them, and scores them — to **gate Phase 3 (the LLM reranker tier)** of the top-N/pluggable-reranker feature, and to feed the BioMapper preprint. Runs as a new "annotation-reranking" scenario of the Local-vs-Cloud Model Ablation Study.

Design docs: the ablation design (vault `docs/plans/2026-07-06-001-feat-annotation-reranking-ablation-design.md`) and this repo's `docs/plans/2026-07-06-002-feat-annotation-reranking-harness-plan.md`. Aligned with the **Revision 2026-07-08** of `docs/plans/2026-07-06-001-feat-topn-pluggable-reranker-design.md`.

### What's here
- `dataset` · `retrieval` (top-N via `_kestrel_hybrid_search`, `equivalent_ids` enrichment) · `inchikey_resolver` (layered KG→MW→PubChem) · `regimes` + `phase0` (retrievability/divergence gate) · `rerankers/{base,deterministic,llm}` · `model_call` (Anthropic/OpenAI/OpenRouter) · `scoring` (exact McNemar, Wilson CI) · `run` (orchestrator) · `labels` (InChIKey label derivation) · `README`.
- **118 unit tests, all network mocked.**

### Methodology hazards encoded in code (not just docs)
- **Circularity #1:** `rm_anchor` retired as default (it's RM=RefMet, circular); primary baseline is `source_weight_guard` (guarded source-weighting + InChIKey connectivity). `rm_anchor` kept only to demonstrate the circularity.
- **Circularity #2 / independent labels:** `labels.py` derives non-circular **InChIKey first-block connectivity** labels (`--derive-labels`), scaling the eval past the ~13 hand-triaged cases; same-connectivity stereo/protonation cases → `expert_needed`, excluded from the skill set.
- **RM leakage:** LLM rerankers run blinded (RM: id stripped) vs unblinded.
- **Retrieval ceiling:** ~45/172 correct nodes absent at top-N≥200; accuracy reported conditioned on retrievability.
- **Reproducibility SOP:** results saved to a timestamped path by default; manifest pins dataset SHA, model ids, seeds, temperature=0, quantization note, hardware.

### Status — build-complete, NOT yet run live
This PR is the harness only. It has **not been run**: no Phase 0 regime measurement, no model matrix. Phase 0 is a hard gate (stop-and-report the regime/recall numbers before any model spend).

**Run prerequisites (follow-up, not in this PR):** pin the exact GPT-5.5-class `model_id` (`PIN_AT_RUNTIME`); add `openai` + `anthropic` to project deps; API keys/budget.

🤖 Co-authored with Claude Code (Opus) via subagent-driven development; every task was independently reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
