### PR TITLE
promote(engine): Kestrel retry + Entity NaN coercion + structure-resolver InChIKey blocks

### DIFF
--- a/src/biomapper2/core/structure_resolver.py
+++ b/src/biomapper2/core/structure_resolver.py
@@ -59,6 +59,27 @@ class StructureResolver:
         self._name_cache[node_name] = block
         return block
 
+    def inchikey_blocks(
+        self, node_id: str, node_name: str | None, records: dict[str, Any] | None = None
+    ) -> set[str]:
+        """ALL KG-asserted InChIKey first-blocks for a node (the full ``equivalent_ids`` list).
+
+        ``inchikey_block`` returns only ``keys[0]``; a KG node's INCHIKEY list is multi-valued
+        (neutral parent, conjugate anion, salt, stereoisomers) and ``keys[0]`` ordering is arbitrary,
+        so a gold structure can match a *non-first* entry (the Hajjar keys[0] artifact). This returns
+        the union of every entry's first-block, letting a scorer test set membership instead of
+        equality against one arbitrary representation. When the KG lists no InChIKey, falls back to
+        the singular name-resolution path (a singleton, or empty when unresolvable) — never a
+        spurious block.
+        """
+        records = records if records is not None else self.linker.get_node_records([node_id])
+        keys = ((records.get(node_id) or {}).get("equivalent_ids") or {}).get("INCHIKEY") or []
+        blocks = {b for b in (self._first_block(k) for k in keys if k) if b}
+        if blocks:
+            return blocks
+        single = self.inchikey_block(node_id, node_name, records)
+        return {single} if single else set()
+
     @staticmethod
     def _first_block(inchikey: str | None) -> str | None:
         return inchikey.split("-")[0] if inchikey else None

--- a/src/biomapper2/models.py
+++ b/src/biomapper2/models.py
@@ -19,6 +19,16 @@ if TYPE_CHECKING:
 AssignedIDsDict = dict[str, dict[str, dict[str, dict[str, Any]]]]
 
 
+def _nan_to_none(data: dict[str, Any]) -> dict[str, Any]:
+    """Coerce pandas/NumPy float ``NaN`` scalars to ``None`` in a Series-derived dict.
+
+    ``pd.Series.to_dict()`` yields ``NaN`` (a float) for empty cells, which fails the Entity's
+    ``str | None`` resolution fields (pydantic rejects a float for a string field). Only scalar
+    float NaN is converted — real values and list/dict fields pass through untouched.
+    """
+    return {k: (None if isinstance(v, float) and v != v else v) for k, v in data.items()}
+
+
 class Entity(BaseModel):
     """
     Represents a biological entity being mapped to a knowledge graph.
@@ -78,7 +88,7 @@ class Entity(BaseModel):
         import pandas as pd
 
         if isinstance(item, pd.Series):
-            data = item.to_dict()
+            data = _nan_to_none(item.to_dict())
         else:
             data = dict(item)
 
@@ -123,5 +133,5 @@ class Entity(BaseModel):
             New Entity with merged fields
         """
         current = self.to_dict()
-        current.update(series.to_dict())
+        current.update(_nan_to_none(series.to_dict()))
         return Entity(**current)

--- a/src/biomapper2/utils.py
+++ b/src/biomapper2/utils.py
@@ -5,6 +5,7 @@ Provides logging setup and mathematical helpers for metric calculations.
 """
 
 import logging
+import time
 from collections.abc import Iterator
 from datetime import timedelta
 from typing import Any, Literal, TypeGuard
@@ -112,13 +113,25 @@ def safe_divide(numerator, denominator) -> float | None:
 
 
 def bulk_kestrel_request(
-    method: str, endpoint: str, session: requests.Session | None = None, auth_required: bool = True, **kwargs
+    method: str,
+    endpoint: str,
+    session: requests.Session | None = None,
+    auth_required: bool = True,
+    *,
+    max_retries: int = 3,
+    retry_backoff_base: float = 2.0,
+    **kwargs,
 ) -> Any:
     """
     Make a single Kestrel API request with the full payload.
 
     This is the low-level function that sends one request. For batching support,
     use kestrel_request() instead.
+
+    Transient server-side failures (HTTP 5xx) and connection/timeout errors are
+    retried with exponential backoff; client errors (4xx) are raised immediately
+    since they will not self-heal. A single Kestrel blip therefore no longer kills
+    a long batch run.
 
     Args:
         method: HTTP method ('GET' or 'POST')
@@ -127,14 +140,19 @@ def bulk_kestrel_request(
         auth_required: Whether to include the API key header. When False, the
             request is sent without authentication (e.g. for GET /categories).
             Default is True to preserve existing behavior.
+        max_retries: Number of retries on transient errors (5xx / connection /
+            timeout) before giving up. 0 disables retrying.
+        retry_backoff_base: Base for exponential backoff; the delay before retry
+            ``attempt`` (0-indexed) is ``retry_backoff_base ** attempt`` seconds.
         **kwargs: Additional arguments to pass to requests (json, params, etc.)
 
     Returns:
         JSON response from API
 
     Raises:
-        requests.exceptions.HTTPError: If API returns error status
-        requests.exceptions.RequestException: If request fails
+        requests.exceptions.HTTPError: If API returns error status (after retries
+            for 5xx; immediately for 4xx)
+        requests.exceptions.RequestException: If request fails after retries
     """
     # Sort search_text in json payload for consistent cache keys (if handling a batch)
     if "json" in kwargs and isinstance(kwargs["json"], dict):
@@ -153,16 +171,44 @@ def bulk_kestrel_request(
     if auth_required:
         headers["X-API-Key"] = get_kestrel_api_key()
 
-    try:
-        response = session.request(method, f"{KESTREL_API_URL}/{endpoint}", headers=headers, **kwargs)
-        response.raise_for_status()
-        return response.json()
-    except requests.exceptions.HTTPError as e:
-        logging.error(f"Kestrel API HTTP error ({endpoint}): {e}", exc_info=True)
-        raise
-    except requests.exceptions.RequestException as e:
-        logging.error(f"Kestrel API request failed ({endpoint}): {e}", exc_info=True)
-        raise
+    url = f"{KESTREL_API_URL}/{endpoint}"
+    transient = (
+        requests.exceptions.ConnectionError,
+        requests.exceptions.Timeout,
+        requests.exceptions.ChunkedEncodingError,
+    )
+    for attempt in range(max_retries + 1):
+        try:
+            response = session.request(method, url, headers=headers, **kwargs)
+            response.raise_for_status()
+            return response.json()
+        except requests.exceptions.HTTPError as e:
+            status = getattr(e.response, "status_code", None)
+            # Retry only transient server errors (5xx); 4xx (auth, bad payload) won't self-heal.
+            if status is not None and 500 <= status < 600 and attempt < max_retries:
+                delay = retry_backoff_base**attempt
+                logging.warning(
+                    f"Kestrel API {status} on {endpoint} "
+                    f"(attempt {attempt + 1}/{max_retries + 1}); retrying in {delay:.1f}s"
+                )
+                time.sleep(delay)
+                continue
+            logging.error(f"Kestrel API HTTP error ({endpoint}): {e}", exc_info=True)
+            raise
+        except transient as e:
+            if attempt < max_retries:
+                delay = retry_backoff_base**attempt
+                logging.warning(
+                    f"Kestrel API transient error on {endpoint} ({type(e).__name__}) "
+                    f"(attempt {attempt + 1}/{max_retries + 1}); retrying in {delay:.1f}s"
+                )
+                time.sleep(delay)
+                continue
+            logging.error(f"Kestrel API request failed ({endpoint}): {e}", exc_info=True)
+            raise
+        except requests.exceptions.RequestException as e:
+            logging.error(f"Kestrel API request failed ({endpoint}): {e}", exc_info=True)
+            raise
 
 
 def kestrel_request(


### PR DESCRIPTION
Promotes three already-reviewed resolver fixes from `fork/dev` (trentleslie/biomapper2) to Phenome-Health `dev`, so the production engine the BioMapper preprint cites contains them. This is the **codebase-only** slice of the benchmark work (3 files, +92/−15); the large `studies/` benchmark harness that exercises these lands as a separate PR.

## Changes
- **`utils.py`** — retry `bulk_kestrel_request` on transient 5xx / connection errors (originally trentleslie#29).
- **`models.py`** — coerce Series `NaN` to `None` in `Entity`, unblocking the Phase-0 gate smoke that otherwise false-failed as "Kestrel unreachable" (originally trentleslie#37).
- **`core/structure_resolver.py`** — additive `inchikey_blocks()` helper used by the structure-oracle scoring (originally trentleslie#36).

## Notes
- Each change was reviewed and merged individually on `fork/dev`; this is a promotion, not new code. No new imports/dependencies; `py_compile` clean.
- Independent of the in-flight Goslin lipid-annotator work (trentleslie#41), which touches different engine files and promotes separately.
- Does not include the benchmarking `pyproject` `studies` extra or `studies/` tree (those go with the harness PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)